### PR TITLE
schema: Phase 1 DB 마이그레이션 전체 추가 (001~008)

### DIFF
--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,384 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "JaengYeo"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/migrations/001_update_updated_at_trigger.sql
+++ b/supabase/migrations/001_update_updated_at_trigger.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/migrations/002_mid_categories.sql
+++ b/supabase/migrations/002_mid_categories.sql
@@ -1,0 +1,34 @@
+CREATE TABLE mid_categories (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+                -- NULL이면 시스템 기본값, NOT NULL이면 사용자 커스텀
+  main_category TEXT NOT NULL CHECK (main_category IN ('food', 'household')),
+  name          TEXT NOT NULL,
+  icon_name     TEXT,
+  sort_order    INTEGER DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER mid_categories_updated_at
+  BEFORE UPDATE ON mid_categories
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE mid_categories ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_see_system_and_own"
+  ON mid_categories FOR SELECT
+  USING (user_id IS NULL OR auth.uid() = user_id);
+
+CREATE POLICY "users_manage_own"
+  ON mid_categories FOR ALL
+  USING (auth.uid() = user_id);
+
+-- 기본 시드
+INSERT INTO mid_categories (user_id, main_category, name, icon_name) VALUES
+  (NULL, 'food',      '냉장고',  'refrigerator'),
+  (NULL, 'food',      '실온',    'house'),
+  (NULL, 'household', '주방',    'fork.knife'),
+  (NULL, 'household', '거실',    'sofa'),
+  (NULL, 'household', '화장실',  'shower'),
+  (NULL, 'household', '창고',    'archivebox');

--- a/supabase/migrations/003_sub_categories.sql
+++ b/supabase/migrations/003_sub_categories.sql
@@ -1,0 +1,40 @@
+CREATE TABLE sub_categories (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  main_category TEXT NOT NULL CHECK (main_category IN ('food', 'household')),
+  name          TEXT NOT NULL,
+  icon_name     TEXT,
+  thumbnail_key TEXT,
+  sort_order    INTEGER DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER sub_categories_updated_at
+  BEFORE UPDATE ON sub_categories
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE sub_categories ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_see_system_and_own"
+  ON sub_categories FOR SELECT
+  USING (user_id IS NULL OR auth.uid() = user_id);
+
+CREATE POLICY "users_manage_own"
+  ON sub_categories FOR ALL
+  USING (auth.uid() = user_id);
+
+-- 식재료 기본 시드
+INSERT INTO sub_categories (user_id, main_category, name, icon_name, thumbnail_key) VALUES
+  (NULL, 'food', '채소',   'leaf',           'thumb_vegetable'),
+  (NULL, 'food', '육류',   'fork.knife',     'thumb_meat'),
+  (NULL, 'food', '해산물', 'fish',           'thumb_seafood'),
+  (NULL, 'food', '유제품', 'cup.and.saucer', 'thumb_dairy'),
+  (NULL, 'food', '음료',   'drop',           'thumb_beverage'),
+  (NULL, 'food', '주류',   'wineglass',      'thumb_alcohol'),
+  (NULL, 'food', '조미료', 'cart',           'thumb_seasoning'),
+  (NULL, 'food', '향신료', 'leaf.fill',      'thumb_spice'),
+  (NULL, 'food', '디저트', 'birthday.cake',  'thumb_dessert'),
+  (NULL, 'food', '과자',   'star',           'thumb_snack'),
+  (NULL, 'food', '곡류',   'bag',            'thumb_grain'),
+  (NULL, 'food', '견과류', 'circle.fill',    'thumb_nut');

--- a/supabase/migrations/004_items.sql
+++ b/supabase/migrations/004_items.sql
@@ -1,0 +1,43 @@
+CREATE TABLE items (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- 기본 정보
+  name            TEXT NOT NULL,
+  quantity        INTEGER NOT NULL DEFAULT 1,
+  quantity_unit   TEXT,
+
+  -- 카테고리
+  main_category   TEXT NOT NULL CHECK (main_category IN ('food', 'household')),
+  mid_category_id UUID REFERENCES mid_categories(id),
+  sub_category_id UUID REFERENCES sub_categories(id),
+
+  -- 선택 필드
+  purchase_date   TIMESTAMPTZ,
+  expiry_date     TIMESTAMPTZ,
+  price           INTEGER,
+  location_memo   TEXT,
+  memo            TEXT,
+  image_url       TEXT,
+
+  -- 상태
+  is_classified                     BOOLEAN NOT NULL DEFAULT true,
+  is_favorite                       BOOLEAN NOT NULL DEFAULT false,
+  is_low_stock_notification_enabled BOOLEAN NOT NULL DEFAULT false,
+  low_stock_threshold               INTEGER NOT NULL DEFAULT 1,
+
+  -- 동기화
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at  TIMESTAMPTZ          -- 소프트 삭제
+);
+
+CREATE TRIGGER items_updated_at
+  BEFORE UPDATE ON items
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_own_items"
+  ON items FOR ALL
+  USING (auth.uid() = user_id AND deleted_at IS NULL);

--- a/supabase/migrations/005_item_quantity_logs.sql
+++ b/supabase/migrations/005_item_quantity_logs.sql
@@ -1,0 +1,15 @@
+CREATE TABLE item_quantity_logs (
+  id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  item_id   UUID REFERENCES items(id) ON DELETE SET NULL,
+  item_name TEXT NOT NULL,   -- 아이템 삭제 후에도 패턴 분석 가능하도록 복사
+  delta     INTEGER NOT NULL,
+  reason    TEXT CHECK (reason IN ('purchase', 'consume', 'adjust', 'delete')),
+  logged_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE item_quantity_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_own_logs"
+  ON item_quantity_logs FOR ALL
+  USING (auth.uid() = user_id);

--- a/supabase/migrations/006_consumption_patterns.sql
+++ b/supabase/migrations/006_consumption_patterns.sql
@@ -1,0 +1,15 @@
+CREATE TABLE consumption_patterns (
+  id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  item_name                 TEXT NOT NULL,
+  avg_days_between_purchase NUMERIC,
+  avg_consumption_rate      NUMERIC,
+  last_calculated_at        TIMESTAMPTZ,
+  UNIQUE(user_id, item_name)
+);
+
+ALTER TABLE consumption_patterns ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_own_patterns"
+  ON consumption_patterns FOR ALL
+  USING (auth.uid() = user_id);

--- a/supabase/migrations/007_barcode_cache.sql
+++ b/supabase/migrations/007_barcode_cache.sql
@@ -1,0 +1,9 @@
+CREATE TABLE barcode_cache (
+  barcode       TEXT PRIMARY KEY,
+  product_name  TEXT,
+  manufacturer  TEXT,
+  raw_response  JSONB,
+  cached_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  hit_count     INTEGER DEFAULT 1
+);
+-- RLS 없음 — 전체 사용자 공유 캐시

--- a/supabase/migrations/008_dev_user_seed.sql
+++ b/supabase/migrations/008_dev_user_seed.sql
@@ -1,0 +1,7 @@
+-- Phase 2 완료(Sign in with Apple 연동) 후 이 마이그레이션을 제거하거나 롤백한다
+INSERT INTO auth.users (
+  id, email, encrypted_password, created_at, updated_at, role
+) VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  'dev@test.com', '', now(), now(), 'authenticated'
+) ON CONFLICT (id) DO NOTHING;

--- a/supabase/migrations/009_fix_items_rls.sql
+++ b/supabase/migrations/009_fix_items_rls.sql
@@ -1,0 +1,27 @@
+-- items RLS 정책 수정
+-- 기존 FOR ALL 정책은 소프트 삭제(UPDATE deleted_at) 시 WITH CHECK에서 막히는 문제가 있음
+-- SELECT/INSERT/UPDATE/DELETE를 분리하여 소프트 삭제가 정상 동작하도록 수정
+
+DROP POLICY IF EXISTS "users_own_items" ON items;
+
+-- SELECT: 삭제되지 않은 본인 아이템만 조회
+CREATE POLICY "users_select_own_items"
+  ON items FOR SELECT
+  USING (auth.uid() = user_id AND deleted_at IS NULL);
+
+-- INSERT: 본인 user_id로만 삽입 가능
+CREATE POLICY "users_insert_own_items"
+  ON items FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- UPDATE: 삭제되지 않은 본인 아이템만 수정 가능 (소프트 삭제 포함)
+-- WITH CHECK에서 deleted_at 조건을 제거하여 소프트 삭제 허용
+CREATE POLICY "users_update_own_items"
+  ON items FOR UPDATE
+  USING (auth.uid() = user_id AND deleted_at IS NULL)
+  WITH CHECK (auth.uid() = user_id);
+
+-- DELETE: 물리 삭제는 사용하지 않으나 방어적으로 추가
+CREATE POLICY "users_delete_own_items"
+  ON items FOR DELETE
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- `001` `update_updated_at` 공통 트리거 함수 정의
- `002` `mid_categories` 테이블 + 기본 시드 6종 (냉장고/실온/주방/거실/화장실/창고)
- `003` `sub_categories` 테이블 + 식재료 시드 12종
- `004` `items` 테이블 (RLS, 소프트 삭제)
- `005` `item_quantity_logs` 테이블 (RLS)
- `006` `consumption_patterns` 테이블 (RLS)
- `007` `barcode_cache` 테이블 (공유 캐시, RLS 없음)
- `008` 개발용 임시 유저 시드 (Phase 2 완료 후 삭제 예정)

## Test plan
- [ ] `supabase db push`로 원격 DB 적용 확인
- [ ] Supabase Dashboard → Table Editor에서 테이블 생성 확인
- [ ] `auth.users`에 고정 UUID 유저(`dev@test.com`) 삽입 확인
- [ ] `mid_categories`, `sub_categories` 시드 데이터 정상 삽입 확인