### PR TITLE
🐛fix: CoreDataManager syncStatus 업데이트 버그 수정

### DIFF
--- a/JaengYeo/JaengYeo/Data/CoreData/CoreDataManager.swift
+++ b/JaengYeo/JaengYeo/Data/CoreData/CoreDataManager.swift
@@ -458,7 +458,7 @@ extension CoreDataManager {
     }
     
     func updateProductSyncStatus(id: UUID) throws {
-        let entity = fetchProductEntity(of: id)
+        let entity = try fetchProductEntity(of: id)
         entity.syncStatus = SyncStatus.synced.rawValue
         do {
             try context.save()
@@ -502,7 +502,7 @@ extension CoreDataManager {
     }
     
     func updateSubCategorySyncStatus(id: UUID) throws {
-        let entity = try fetchMidCategoryEntity(of: id)
+        let entity = try fetchSubCategoryEntity(of: id)
         entity.syncStatus = SyncStatus.synced.rawValue
         do {
             try context.save()


### PR DESCRIPTION
## Summary
- `updateProductSyncStatus`: `try` 키워드 누락으로 인한 컴파일 에러 수정
- `updateSubCategorySyncStatus`: `fetchMidCategoryEntity` → `fetchSubCategoryEntity` 잘못된 entity 조회 수정 (SubCategory 동기화 시 MidCategory를 업데이트하던 버그)

## Test plan
- [ ] 오프라인 상태에서 아이템 추가 후 온라인 복귀 시 SubCategory syncStatus가 정상적으로 synced로 변경되는지 확인
- [ ] 빌드 에러 없이 컴파일 되는지 확인