### PR TITLE
Feat/coordinator#33

### DIFF
--- a/JaengYeo/JaengYeo/Application/AppCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/AppCoordinator.swift
@@ -1,0 +1,55 @@
+//
+//  AppCoordinator.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/7/26.
+//
+
+import UIKit
+
+final class AppCoordinator {
+    private let window: UIWindow
+    
+    init(window: UIWindow) {
+        self.window = window
+    }
+    
+    func start() {
+        let client = makeSupabaseClient()
+        let productManager = ProductManager(client: client)
+        let categoryManager = CategoryManager(client: client)
+        let coreDataManager = CoreDataManager()
+        let syncManager = SyncManager(
+            productManager: productManager,
+            categoryManager: categoryManager,
+            coreDataManager: coreDataManager
+        )
+        syncManager.networkCheck()
+        
+        let homeCoordinator = HomeCoordinator(
+            productManager: productManager,
+            categoryManager: categoryManager,
+            coreDataManager: coreDataManager
+        )
+        
+        let registerCoordinator = RegisterCoordinator(
+            productManager: productManager,
+            categoryManager: categoryManager,
+            coreDataManager: coreDataManager
+        )
+        
+        let stockCoordinator = StockCoordinator(
+            productManager: productManager,
+            categoryManager: categoryManager,
+            coreDataManager: coreDataManager
+        )
+        
+        let mainController = MainController(
+            homeNavigationController: homeCoordinator.navigationController,
+            registerNavigationController: registerCoordinator.navigationController,
+            stockNavigationController: stockCoordinator.navigationController
+        )
+        window.rootViewController = mainController
+        window.makeKeyAndVisible()
+    }
+}

--- a/JaengYeo/JaengYeo/Application/AppCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/AppCoordinator.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class AppCoordinator {
     private let window: UIWindow
+    private var syncManager: SyncManagerProtocol?
+    private var childCoordinators: [Any] = []
     
     init(window: UIWindow) {
         self.window = window
@@ -25,6 +27,7 @@ final class AppCoordinator {
             coreDataManager: coreDataManager
         )
         syncManager.networkCheck()
+        self.syncManager = syncManager
         
         let homeCoordinator = HomeCoordinator(
             productManager: productManager,
@@ -43,7 +46,7 @@ final class AppCoordinator {
             categoryManager: categoryManager,
             coreDataManager: coreDataManager
         )
-        
+        childCoordinators = [homeCoordinator, registerCoordinator, stockCoordinator]
         let mainController = MainController(
             homeNavigationController: homeCoordinator.navigationController,
             registerNavigationController: registerCoordinator.navigationController,

--- a/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
@@ -19,7 +19,7 @@ final class HomeCoordinator {
         self.categoryManager = categoryManager
         self.coreDataManager = coreDataManager
         
-        let viewController = ViewController()
+        let viewController = HomeViewController()
         navigationController = UINavigationController(rootViewController: viewController)
         navigationController.tabBarItem = UITabBarItem(
             title: "홈",

--- a/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
@@ -1,0 +1,30 @@
+//
+//  HomeCoordinator.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/7/26.
+//
+
+import UIKit
+
+final class HomeCoordinator {
+    let navigationController: UINavigationController
+    
+    private let productManager: ProductManagerProtocol
+    private let categoryManager: CategoryManagerProtocol
+    private let coreDataManager: CoreDataManagerProtocol
+    
+    init(productManager: ProductManagerProtocol, categoryManager: CategoryManagerProtocol, coreDataManager: CoreDataManagerProtocol) {
+        self.productManager = productManager
+        self.categoryManager = categoryManager
+        self.coreDataManager = coreDataManager
+        
+        let viewController = ViewController()
+        navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.tabBarItem = UITabBarItem(
+            title: "홈",
+            image: UIImage(systemName: "house"),
+            selectedImage: UIImage(systemName: "house.fill")
+        )
+    }
+}

--- a/JaengYeo/JaengYeo/Application/RegisterCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/RegisterCoordinator.swift
@@ -1,0 +1,30 @@
+//
+//  RegisterCoordinator.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/7/26.
+//
+
+import UIKit
+
+final class RegisterCoordinator {
+    let navigationController: UINavigationController
+    
+    private let productManager: ProductManagerProtocol
+    private let categoryManager: CategoryManagerProtocol
+    private let coreDataManager: CoreDataManagerProtocol
+    
+    init(productManager: ProductManagerProtocol, categoryManager: CategoryManagerProtocol, coreDataManager: CoreDataManagerProtocol) {
+        self.productManager = productManager
+        self.categoryManager = categoryManager
+        self.coreDataManager = coreDataManager
+        
+        let viewController = RegisterViewController()
+        navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.tabBarItem = UITabBarItem(
+            title: "등록",
+            image: UIImage(systemName: "camera"),
+            selectedImage: UIImage(systemName: "camera.fill")
+        )
+    }
+}

--- a/JaengYeo/JaengYeo/Application/SceneDelegate.swift
+++ b/JaengYeo/JaengYeo/Application/SceneDelegate.swift
@@ -10,14 +10,15 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    private var appCoordinator: AppCoordinator?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = MainController()
-        window.makeKeyAndVisible()
         self.window = window
+        let coordinator = AppCoordinator(window: window)
+        self.appCoordinator = coordinator
+        coordinator.start()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/JaengYeo/JaengYeo/Application/StockCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/StockCoordinator.swift
@@ -1,0 +1,30 @@
+//
+//  StockCoordinator.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/7/26.
+//
+
+import UIKit
+
+final class StockCoordinator {
+    let navigationController: UINavigationController
+    
+    private let productManager: ProductManagerProtocol
+    private let categoryManager: CategoryManagerProtocol
+    private let coreDataManager: CoreDataManagerProtocol
+    
+    init(productManager: ProductManagerProtocol, categoryManager: CategoryManagerProtocol, coreDataManager: CoreDataManagerProtocol) {
+        self.productManager = productManager
+        self.categoryManager = categoryManager
+        self.coreDataManager = coreDataManager
+        
+        let viewController = StockViewController()
+        navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.tabBarItem = UITabBarItem(
+            title: "재고",
+            image: UIImage(systemName: "bag"),
+            selectedImage: UIImage(systemName: "bag.fill")
+        )
+    }
+}

--- a/JaengYeo/JaengYeo/Network/SupabaseConfigurator.swift
+++ b/JaengYeo/JaengYeo/Network/SupabaseConfigurator.swift
@@ -17,6 +17,11 @@ func makeSupabaseClient() -> SupabaseClient {
     
     return SupabaseClient(
         supabaseURL: url,
-        supabaseKey: key
+        supabaseKey: key,
+        options: SupabaseClientOptions(
+            auth: SupabaseClientOptions.AuthOptions(
+                emitLocalSessionAsInitialSession: true 
+            )
+        )
     )
 }

--- a/JaengYeo/JaengYeo/View/Common/RegisterViewController.swift
+++ b/JaengYeo/JaengYeo/View/Common/RegisterViewController.swift
@@ -1,0 +1,8 @@
+//
+//  RegisterViewController.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/7/26.
+//
+
+import Foundation

--- a/JaengYeo/JaengYeo/View/Common/RegisterViewController.swift
+++ b/JaengYeo/JaengYeo/View/Common/RegisterViewController.swift
@@ -1,8 +1,0 @@
-//
-//  RegisterViewController.swift
-//  JaengYeo
-//
-//  Created by 손영빈 on 4/7/26.
-//
-
-import Foundation

--- a/JaengYeo/JaengYeo/View/HomeViewController.swift
+++ b/JaengYeo/JaengYeo/View/HomeViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/2/26.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/JaengYeo/JaengYeo/View/MainController.swift
+++ b/JaengYeo/JaengYeo/View/MainController.swift
@@ -9,6 +9,23 @@ import UIKit
 
 class MainController: UITabBarController {
     
+    init(
+        homeNavigationController: UINavigationController,
+        registerNavigationController: UINavigationController,
+        stockNavigationController: UINavigationController
+    ) {
+        super.init(nibName: nil, bundle: nil)
+        viewControllers = [
+            homeNavigationController,
+            registerNavigationController,
+            stockNavigationController
+        ]
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
@@ -18,19 +35,8 @@ class MainController: UITabBarController {
 
 extension MainController {
     private func setupTabBar() {
-        let homeVC = createNC(rootVC: ViewController(), title: "홈", image: "house")
-        let registerVC = createNC(rootVC: ViewController(), title: "등록", image: "camera")
-        let stockVC = createNC(rootVC: ViewController(), title: "재고", image: "bag")
         //TODO: TabBar 색상 및 스타일 설정 필요
 //        tabBar.tintColor =
 //        tabBar.unselectedItemTintColor =
-        viewControllers = [homeVC, registerVC, stockVC]
-    }
-    
-    private func createNC(rootVC: UIViewController, title: String, image: String) -> UINavigationController {
-        let nc = UINavigationController(rootViewController: rootVC)
-        nc.tabBarItem.title = title
-        nc.tabBarItem.image = UIImage(systemName: image)
-        return nc
     }
 }

--- a/JaengYeo/JaengYeo/View/RegisterViewController.swift
+++ b/JaengYeo/JaengYeo/View/RegisterViewController.swift
@@ -1,0 +1,8 @@
+//
+//  RegisterViewController.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/7/26.
+//
+
+import Foundation

--- a/JaengYeo/JaengYeo/View/RegisterViewController.swift
+++ b/JaengYeo/JaengYeo/View/RegisterViewController.swift
@@ -5,4 +5,10 @@
 //  Created by 손영빈 on 4/7/26.
 //
 
-import Foundation
+import UIKit
+
+class RegisterViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/JaengYeo/JaengYeo/View/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/StockViewController.swift
@@ -5,4 +5,10 @@
 //  Created by 손영빈 on 4/7/26.
 //
 
-import Foundation
+import UIKit
+
+class StockViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/JaengYeo/JaengYeo/View/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/StockViewController.swift
@@ -1,0 +1,8 @@
+//
+//  StockViewController.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/7/26.
+//
+
+import Foundation


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)                                                                                       
  Closes #33 
                                                                        
  ## 🛠 작업 내용 (What I did)
  - Coordinator 패턴 도입 (AppCoordinator, HomeCoordinator, RegisterCoordinator, StockCoordinator)
  - AppCoordinator에서 모든 의존성 생성 및 각 Coordinator로 주입
  - MainController: 외부에서 NavigationController를 주입받는 init으로 변경
  - SceneDelegate: AppCoordinator 연결 및 강한 참조 보유
  - SyncManager.networkCheck() 앱 시작 시점에 연결

  ## 💻 구현 상세 (Implementation Details)                                                                              
  - 의존성 흐름: SceneDelegate → AppCoordinator → Home/Register/StockCoordinator → MainController
  - 각 Coordinator가 NavigationController를 소유하고 탭 아이템 설정 담당
  - ViewModel 생성 책임은 각 Coordinator가 담당 (화면 구현 단계에서 적용)
  - 현재 각 탭의 rootViewController는 placeholder (화면 구현 시 교체 예정)

  ## ✅ 자가 점검 (Self Checklist)
  - [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
  - [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
  - [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?