### PR TITLE
🌟feat: ProductCell 구현

### DIFF
--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -8,89 +8,250 @@
 import UIKit
 import SnapKit
 import Then
-import RxCocoa
 
-final class ProductCell: UICollectionViewCell {
+/// 공용 상품 셀
+final class ProductCell: UICollectionViewListCell{
     
-    //MARK: - Componenets
+    //MARK: - Enum
+    /// 상품 셀 디자인 타입
+    enum ProductCellType {
+        /// 기본 디자인
+        case defaultType
+        /// 상품 추가 정보 표기 디자인
+        case detailType
+        /// 등록 디자인
+        case registType
+    }
+    
+    // MARK: - Properties
+    private var cellType: ProductCellType
+    
+    // MARK: - Components
     /// 아이템 이미지 뷰
-    let productImageView = UIImageView().then {
+    private let productImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFill
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 8
+        $0.backgroundColor = .accent
     }
     
     /// 아이템 타이틀
-    let productTitleLabel = StyledLabel(config: .bodyMedium14)
+    private let productTitleLabel = StyledLabel(config: .bodyMedium14).then {
+        $0.text = "아이템 타이틀"
+    }
     
     /// 아이템 카운트
-    let productCountLabel = StyledLabel(config: .titleSemi18)
+    private let productCountLabel = StyledLabel(config: .titleSemi18).then {
+        $0.text = "0"
+    }
     
-    /// 아이템 정보 스텍
-    let productDesciptStack = UIStackView().then {
+    /// 카운트 단위
+    private let countUnitLabel = StyledLabel(config: .body12.updatingColor(color: .gray300)).then {
+        $0.text = "개"
+    }
+    
+    /// 메인 스택
+    private let productMainStack = UIStackView().then {
         $0.axis = .horizontal
+        $0.spacing = 16
+        $0.alignment = .center
+        $0.distribution = .fill
+    }
+    
+    /// 정보 스택
+    private let productInfoStack = UIStackView().then {
+        $0.axis = .vertical
         $0.spacing = 4
         $0.alignment = .leading
-        $0.distribution = .equalSpacing
+        $0.distribution = .fill
     }
     
-    //MARK: - Init
-    override init(frame: CGRect) {
-        super.init(frame: .zero)
+    /// 메인 설명 스택
+    private let productDescriptionStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 4
+        $0.alignment = .center
+        $0.distribution = .fill
     }
     
+    /// 서브 설명 스택
+    private let productSubDescriptionStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 4
+        $0.alignment = .center
+        $0.distribution = .fill
+    }
+    
+    /// 수량 뷰
+    private let productCountView = UIView()
+    
+    // MARK: - Init
+    init(frame: CGRect = .zero, type: ProductCellType) {
+        self.cellType = type
+        super.init(frame: frame)
+        configureUI()
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    convenience init(type: ProductCellType) {
+        self.init(frame: .zero, type: type)
+    }
 }
 
+// MARK: - Public
 extension ProductCell {
-    
-    func configureUI() {
-     
-        let productMainStack = UIStackView().then {
-            $0.axis = .horizontal
-            $0.spacing = 16
-            $0.alignment = .leading
-            $0.distribution = .fillProportionally
+    /// Update UI 메소드
+    func updateUI(
+        title: String,
+        freshness: Int?,
+        descriptions: [String]?,
+        subdescriptions: [String]?,
+        count: Int?
+    ) {
+        productTitleLabel.text = title
+        
+        updateDescriptionStack(
+            stackView: productDescriptionStack,
+            freshness: freshness,
+            texts: descriptions,
+        )
+        
+        if cellType != .registType, let count = count {
+            productCountLabel.text = "\(count)"
         }
         
-        let productInfoStack = UIStackView().then {
-            $0.axis = .vertical
-            $0.spacing = 4
-            $0.alignment = .leading
-            $0.distribution = .fillProportionally
-        }
-    
-        let productCountStack = UIStackView().then {
-            $0.axis = .horizontal
-            $0.spacing = 0
-            $0.alignment = .center
-            $0.distribution = .equalSpacing
+        if cellType == .detailType {
+            updateDescriptionStack(
+                stackView: productSubDescriptionStack,
+                freshness: nil,
+                texts: subdescriptions,
+            )
         }
         
-        let countLabel = StyledLabel(config: .body12.updatingColor(color: .gray300))
         
-        productCountStack.addArrangedSubview(productCountLabel)
-        productCountStack.addArrangedSubview(countLabel)
+    }
+}
+
+// MARK: - Update
+private extension ProductCell {
+    /// 설명 스택에 삽입될 텍스트 라벨 제작 메소드
+    private func updateDescriptionStack(
+        stackView: UIStackView,
+        freshness: Int?,
+        texts: [String]?,
+    ) {
+        var labels: [UILabel] = []
         
-        productInfoStack.addArrangedSubview(productTitleLabel)
-        productInfoStack.addArrangedSubview(productDesciptStack)
-        productMainStack.addArrangedSubview(productImageView)
-        productMainStack.addArrangedSubview(productInfoStack)
+        /// 유통기한 텍스트 생성
+        if let freshness {
+            let freshnessLabel = StyledLabel(
+                config: .body12.updatingColor(color: .primaryRed)
+            ).then {
+                $0.text = freshness > 0 ? "\(freshness)일 남음" : "소비기한 만료"
+                $0.numberOfLines = 1
+            }
+            labels.append(freshnessLabel)
+        }
         
-        contentView.addSubview(productInfoStack)
-        contentView.addSubview(productCountStack)
+        /// 설명 라벨 생성
+        texts?.forEach { text in
+            let label = StyledLabel(config: .body12.updatingColor(color: .gray300)).then {
+                $0.text = text
+                $0.numberOfLines = 1
+            }
+            labels.append(label)
+        }
         
-        
-        productMainStack.snp.makeConstraints{
-            $0.top.equalToSuperview().offset(12)
-            $0.bottom.equalToSuperview().inset(12)
-            $0.leading.equalToSuperview().offset(16)
+        /// 스택뷰에 삽입
+        labels.enumerated().forEach { index, label in
+            stackView.addArrangedSubview(label)
+            
+            // dot 라벨 추가
+            if index < labels.count - 1 {
+                let dotLabel = StyledLabel(config: .body12.updatingColor(color: .gray300)).then {
+                    $0.text = "·"
+                    $0.numberOfLines = 1
+                }
+                stackView.addArrangedSubview(dotLabel)
+            }
         }
     }
 }
 
-#Preview{
-    ProductCell()
+
+// MARK: - Layout
+private extension ProductCell {
+    
+    func configureUI() {
+        contentView.addSubview(productMainStack)
+        contentView.addSubview(productCountView)
+        
+        productMainStack.addArrangedSubview(productImageView)
+        productMainStack.addArrangedSubview(productInfoStack)
+        
+        productInfoStack.addArrangedSubview(productTitleLabel)
+        productInfoStack.addArrangedSubview(productDescriptionStack)
+        productInfoStack.addArrangedSubview(productSubDescriptionStack)
+        
+        productCountView.addSubview(productCountLabel)
+        productCountView.addSubview(countUnitLabel)
+        
+        productMainStack.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(12)
+            $0.bottom.equalToSuperview().inset(12)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.lessThanOrEqualTo(productCountView.snp.leading).offset(-12)
+        }
+        
+        productCountView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(16)
+        }
+        
+        productImageView.snp.makeConstraints {
+            $0.size.equalTo(64)
+        }
+        
+        productCountLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.trailing.equalTo(countUnitLabel.snp.leading).offset(-2)
+            $0.lastBaseline.equalTo(countUnitLabel.snp.lastBaseline)
+        }
+        
+        countUnitLabel.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+        
+        switch cellType {
+        case .defaultType:
+            productSubDescriptionStack.isHidden = true
+            productCountView.isHidden = false
+            
+        case .detailType:
+            productSubDescriptionStack.isHidden = false
+            productCountView.isHidden = false
+            
+        case .registType:
+            productSubDescriptionStack.isHidden = true
+            productCountView.isHidden = true
+        }
+    }
+}
+
+
+
+#Preview {
+    let cell = ProductCell(type: .detailType)
+    cell.updateUI(
+        title: "바나나",
+        freshness: -1,
+        descriptions: ["실온", "과일"],
+        subdescriptions: ["추가 정보", "라벨4"],
+        count: 6
+    )
+    return cell
 }

--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -141,8 +141,9 @@ private extension ProductCell {
     private func updateDescriptionStack(
         stackView: UIStackView,
         freshness: Int?,
-        texts: [String]?,
+        texts: [String]?
     ) {
+        stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         var labels: [UILabel] = []
         
         /// 유통기한 텍스트 생성

--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -119,8 +119,8 @@ extension ProductCell {
             texts: descriptions,
         )
         
-        if cellType != .registType, let count = count {
-            productCountLabel.text = "\(count)"
+        if cellType != .registType {
+            productCountLabel.text = count.map { String($0) } ?? "0"
         }
         
         if cellType == .detailType {


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #32

## 🛠 작업 내용 (What I did)
- UICollectionViewListCell 기반 공용 상품 셀 구현
- 셀 타입별 UI 분기 처리
- 상품 정보 업데이트 로직 추가
- 설명 스택 동적 구성 로직 반영

## 💻 구현 상세 (Implementation Details)
- UICollectionViewListCell 기반 ProductCell 구현
- 상품 셀 타입별(default, detail, regist) UI 분기 처리
- 상품명, 소비기한, 설명 정보, 수량 업데이트 메소드 추가
- 설명 스택에 동적 라벨 및 구분점 추가 로직 구현
- detail 타입에서 서브 설명 노출 처리 추가
- regist 타입에서 수량 영역 숨김 처리

## 📸 스크린샷 (Screenshots)

### 기본 디자인 타입
<img width="405" height="86" alt="스크린샷 2026-04-08 오후 8 30 41" src="https://github.com/user-attachments/assets/3247ccb9-d4d3-4c68-8ab0-9abbacec6b55" />

### 상세 디자인 타입
<img width="405" height="86" alt="스크린샷 2026-04-08 오후 8 29 55" src="https://github.com/user-attachments/assets/eda19b40-35db-4b2c-9ff8-948c674f16ed" />

### 등록 디자인 타입
<img width="405" height="86" alt="스크린샷 2026-04-08 오후 8 31 34" src="https://github.com/user-attachments/assets/6dc03336-cf9e-4568-b069-fa62e775df81" />


## 🧐 사용 예시 코드(Exmple Code)
```swift
/// 업데이트 메소드 및 파라미터 형식
func updateUI(
        title: String,
        freshness: Int?,
        descriptions: [String]?,
        subdescriptions: [String]?,
        count: Int?
    )

/// 기본 디자인 타입 셀 예시
let defaultCell = ProductCell(type: .defaultType)
defaultCell.updateUI(
    title: "바나나",
    freshness: 5,
    descriptions: ["실온", "과일"],
    subdescriptions: nil,
    count: 6
)

/// 상세 디자인 타입셀
let detailCell = ProductCell(type: .detailType)
detailCell.updateUI(
    title: "우유",
    freshness: 8,
    descriptions: ["냉장", "유제품"],
    subdescriptions: ["서울우유", "대형마트 구매"],
    count: 1
)

/// 등록 디자인 타입셀
let registCell = ProductCell(type: .registType)
registCell.updateUI(
    title: "세제",
    freshness: nil,
    descriptions: ["2026-04-08 등록"],
    subdescriptions: nil,
    count: nil
)
