### PR TITLE
♻️refactor: ProductCell 이미지 설정 및 카드형 레이아웃 보정

### DIFF
--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -112,8 +112,28 @@ final class ProductCell: UICollectionViewListCell{
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        cellType = .defaultType
+        productTitleLabel.text = nil
+        productCountLabel.text = "0"
+        productImageView.image = nil
+        productImageView.backgroundColor = .accent
+        
+        updateDescriptionStack(
+            stackView: productDescriptionStack,
+            freshness: nil,
+            texts: nil
+        )
+        
+        updateDescriptionStack(
+            stackView: productSubDescriptionStack,
+            freshness: nil,
+            texts: nil
+        )
+    }
 }
 
 // MARK: - Public

--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -125,10 +125,13 @@ extension ProductCell {
         freshness: Int?,
         descriptions: [String]?,
         subdescriptions: [String]?,
-        count: Int?
+        count: Int?,
+        image: UIImage?,
     ) {
         cellType = type
         productTitleLabel.text = title
+        productImageView.image = image
+        productImageView.backgroundColor = image == nil ? .accent : .clear
         
         updateDescriptionStack(
             stackView: productDescriptionStack,
@@ -203,6 +206,20 @@ private extension ProductCell {
 private extension ProductCell {
     
     func configureUI() {
+        backgroundColor = .clear
+
+        var backgroundConfig = UIBackgroundConfiguration.clear()
+        backgroundConfig.backgroundColor = .white
+        backgroundConfig.cornerRadius = 8
+        self.backgroundConfiguration = backgroundConfig
+
+        directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 8,
+            leading: 16,
+            bottom: 8,
+            trailing: 16
+        )
+
         contentView.addSubview(productMainStack)
         contentView.addSubview(productCountView)
         
@@ -216,20 +233,21 @@ private extension ProductCell {
         productCountView.addSubview(productCountLabel)
         productCountView.addSubview(countUnitLabel)
         
-        contentView.snp.makeConstraints {
-            $0.height.equalTo(88)
-        }
-        
         productMainStack.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(12)
-            $0.bottom.equalToSuperview().inset(12)
-            $0.leading.equalToSuperview().offset(16)
+            $0.top.equalTo(contentView).offset(12)
+            $0.bottom.equalTo(contentView).inset(12)
+            $0.leading.equalTo(contentView).offset(16)
             $0.trailing.lessThanOrEqualTo(productCountView.snp.leading).offset(-12)
+            $0.height.equalTo(64)
         }
         
         productCountView.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(16)
+            $0.centerY.equalTo(contentView)
+            $0.trailing.equalTo(contentView).inset(16)
+        }
+        
+        productInfoStack.snp.makeConstraints {
+            $0.width.greaterThanOrEqualTo(80)
         }
         
         productImageView.snp.makeConstraints {
@@ -237,7 +255,6 @@ private extension ProductCell {
         }
         
         productCountLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview()
             $0.trailing.equalTo(countUnitLabel.snp.leading).offset(-2)
             $0.lastBaseline.equalTo(countUnitLabel.snp.lastBaseline)
         }


### PR DESCRIPTION
## 🛠 작업 내용 (What I did)
- ProductCell의 updateUI에 이미지 파라미터를 추가했습니다.
- 이미지 유무에 따라 썸네일 배경색이 분기되도록 수정했습니다.
- ProductCell 배경을 카드형 스타일로 보이도록 backgroundConfiguration을 적용했습니다.
- 내부 레이아웃 제약을 contentView 기준으로 정리했습니다.
- 메인 콘텐츠 높이를 64로 고정해 셀 전체 높이 88 구조를 맞췄습니다.
- productInfoStack에 최소 너비 80을 적용해 텍스트 줄바꿈이 비정상적으로 발생하는 문제를 보완했습니다.

## 🧐 체크 포인트 (Review Points)
- 이미지가 있을 때와 없을 때 썸네일 영역이 정상적으로 보이는지
- 셀이 흰 배경의 카드 형태로 표시되는지
- 셀 높이가 88로 의도대로 유지되는지
- 긴 상품명에서도 텍스트 레이아웃이 과도하게 세로로 깨지지 않는지