### PR TITLE
Feat/main#5

### DIFF
--- a/JaengYeo/JaengYeo/Application/AppCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/AppCoordinator.swift
@@ -7,11 +7,14 @@
 
 import UIKit
 import Supabase
+import RxSwift
+import RxCocoa
 
 final class AppCoordinator {
     private let window: UIWindow
     private var syncManager: SyncManagerProtocol?
     private var childCoordinators: [Any] = []
+    private let disposeBag = DisposeBag()
     
     init(window: UIWindow) {
         self.window = window
@@ -81,7 +84,25 @@ final class AppCoordinator {
             registerNavigationController: registerCoordinator.navigationController,
             stockNavigationController: stockCoordinator.navigationController
         )
+        
+        homeCoordinator.navigateToCategory
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak mainController, weak stockCoordinator] category in
+                mainController?.selectedIndex = 2
+                stockCoordinator?.selectMainCategory(name: category)
+            })
+            .disposed(by: disposeBag)
+        
+        registerCoordinator.navigateToStock
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak mainController] in
+                mainController?.selectedIndex = 2
+            })
+            .disposed(by: disposeBag)
+        
         window.rootViewController = mainController
         window.makeKeyAndVisible()
+
+                  
     }
 }

--- a/JaengYeo/JaengYeo/Application/AppCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/AppCoordinator.swift
@@ -10,6 +10,12 @@ import Supabase
 import RxSwift
 import RxCocoa
 
+private enum Tab: Int {
+    case home = 0
+    case register = 1
+    case stock = 2
+}
+
 final class AppCoordinator {
     private let window: UIWindow
     private var syncManager: SyncManagerProtocol?
@@ -88,7 +94,7 @@ final class AppCoordinator {
         homeCoordinator.navigateToCategory
             .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak mainController, weak stockCoordinator] category in
-                mainController?.selectedIndex = 2
+                mainController?.selectedIndex = Tab.stock.rawValue
                 stockCoordinator?.selectMainCategory(name: category)
             })
             .disposed(by: disposeBag)
@@ -96,7 +102,7 @@ final class AppCoordinator {
         registerCoordinator.navigateToStock
             .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak mainController] in
-                mainController?.selectedIndex = 2
+                mainController?.selectedIndex = Tab.stock.rawValue
             })
             .disposed(by: disposeBag)
         

--- a/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
@@ -18,6 +18,8 @@ final class HomeCoordinator {
     private let categoryManager: CategoryManagerProtocol
     private let coreDataManager: CoreDataManagerProtocol
     
+    let navigateToCategory = PublishSubject<String>()
+    
     init(productManager: ProductManagerProtocol, categoryManager: CategoryManagerProtocol, coreDataManager: CoreDataManagerProtocol) {
         self.productManager = productManager
         self.categoryManager = categoryManager
@@ -36,6 +38,10 @@ final class HomeCoordinator {
             .bind(onNext: { [weak self] _ in //TODO: Stock 이동 적용
                 
             })
+            .disposed(by: disposeBag)
+        
+        viewModel.navigateToCategory
+            .bind(to: navigateToCategory)
             .disposed(by: disposeBag)
     }
 }

--- a/JaengYeo/JaengYeo/Application/RegisterCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/RegisterCoordinator.swift
@@ -25,6 +25,8 @@ final class RegisterCoordinator {
     private weak var listViewModel: RegisterItemListViewModel?
     private weak var detailViewController: RegisterDetailViewController?
     
+    let navigateToStock = PublishSubject<Void>()
+    
     init(productManager: ProductManagerProtocol, categoryManager: CategoryManagerProtocol, coreDataManager: CoreDataManagerProtocol, syncManager: SyncManagerProtocol, client: SupabaseClient) {
         self.productManager = productManager
         self.categoryManager = categoryManager
@@ -71,11 +73,9 @@ extension RegisterCoordinator: RegisterViewControllerDelegate {
         
         viewModel.navigateToStock
             .bind(onNext: { [weak self] in
-                self?.navigationController.tabBarController?.selectedIndex = 2
-                //TODO: DispatchQueue로 해도 pop 전환 애니메이션이 잠깐 보이는 문제 있음. 누군가 살려주길 바람.
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                    self?.navigationController.setViewControllers(Array(self?.navigationController.viewControllers.prefix(1) ?? []), animated: false)
-                }
+                guard let self else { return }
+                navigationController.setViewControllers(Array(navigationController.viewControllers.prefix(1)), animated: false)
+                navigateToStock.onNext(())
             })
             .disposed(by: disposeBag)
         

--- a/JaengYeo/JaengYeo/Application/StockCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/StockCoordinator.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class StockCoordinator {
     let navigationController: UINavigationController
+    private let stockViewController: StockViewController
     
     private let productManager: ProductManagerProtocol
     private let categoryManager: CategoryManagerProtocol
@@ -20,11 +21,18 @@ final class StockCoordinator {
         self.coreDataManager = coreDataManager
         
         let viewController = StockViewController(viewModel: StockViewModel(coreDataManager: coreDataManager))
+        self.stockViewController = viewController
         navigationController = UINavigationController(rootViewController: viewController)
         navigationController.tabBarItem = UITabBarItem(
             title: "재고",
             image: UIImage(systemName: "bag"),
             selectedImage: UIImage(systemName: "bag.fill")
         )
+    }
+}
+
+extension StockCoordinator {
+    func selectMainCategory(name: String) {
+        stockViewController.selectMainCategory(name: name)
     }
 }

--- a/JaengYeo/JaengYeo/View/Home/Cell/CategorySubCard.swift
+++ b/JaengYeo/JaengYeo/View/Home/Cell/CategorySubCard.swift
@@ -5,4 +5,72 @@
 //  Created by 손영빈 on 4/15/26.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+import Then
+
+final class CategorySubCard: UIView {
+    private let titleLabel = UILabel().then {
+        $0.font = LabelConfiguration.body12.font
+        $0.textColor = .white
+    }
+    
+    private let countLabel = UILabel().then {
+        $0.font = LabelConfiguration.titleSemi16.font
+        $0.textColor = .white
+    }
+    
+    private let unitLabel = UILabel().then {
+        $0.text = "개"
+        $0.font = LabelConfiguration.body12.font
+        $0.textColor = .white
+    }
+    
+    private let iconImageView = UIImageView().then {
+        $0.tintColor = .white
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    init(title: String, iconName: String) {
+        super.init(frame: .zero)
+        titleLabel.text = title
+        iconImageView.image = UIImage(named: iconName)
+        backgroundColor = .accent
+        layer.cornerRadius = 8
+        clipsToBounds = true
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension CategorySubCard {
+    private func setLayout() {
+        [titleLabel, countLabel, unitLabel, iconImageView].forEach { addSubview($0) }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().offset(8)
+        }
+        countLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(8)
+            $0.bottom.equalToSuperview().offset(-8)
+        }
+        unitLabel.snp.makeConstraints {
+            $0.leading.equalTo(countLabel.snp.trailing)
+            $0.bottom.equalTo(countLabel.snp.bottom).offset(-2)
+        }
+        iconImageView.snp.makeConstraints {
+            $0.trailing.bottom.equalToSuperview().offset(-8)
+            $0.size.equalTo(20)
+        }
+    }
+}
+
+extension CategorySubCard {
+    func config(count: Int) {
+        countLabel.text = "\(count)"
+    }
+}

--- a/JaengYeo/JaengYeo/View/Home/Cell/CategorySubCard.swift
+++ b/JaengYeo/JaengYeo/View/Home/Cell/CategorySubCard.swift
@@ -1,0 +1,8 @@
+//
+//  CategorySubCard.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/15/26.
+//
+
+import Foundation

--- a/JaengYeo/JaengYeo/View/Home/Cell/CategorySummaryCell.swift
+++ b/JaengYeo/JaengYeo/View/Home/Cell/CategorySummaryCell.swift
@@ -5,4 +5,99 @@
 //  Created by 손영빈 on 4/15/26.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+import Then
+
+final class CategorySummaryCell: UICollectionViewCell {
+    static let id = "CategorySummaryCell"
+    
+    private let titleLabel = UILabel().then {
+        $0.font = LabelConfiguration.bodyMedium14.font
+        $0.textColor = .gray800
+    }
+    
+    private let countLabel = UILabel().then {
+        $0.font = LabelConfiguration.titleBold24.font
+        $0.textColor = .accent
+    }
+    
+    private let countUnitLabel = UILabel().then {
+        $0.text = "개"
+        $0.font = LabelConfiguration.body12.font
+        $0.textColor = .gray500
+    }
+    
+    private let chevronImageView = UIImageView().then {
+        $0.image = .arrowIcon
+        $0.tintColor = .gray300
+        $0.contentMode = .scaleAspectFit
+        $0.transform = CGAffineTransform(scaleX: -1, y: 1)
+    }
+    
+    private let midCategoryView = CategorySubCard(title: "중분류", iconName: "locationIcon")
+    private let subCategoryView = CategorySubCard(title: "소분류", iconName: "filterIcon")
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 8
+        contentView.clipsToBounds = true
+        contentView.layer.borderWidth = 1
+        contentView.layer.borderColor = UIColor.gray100.cgColor
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        titleLabel.text = nil
+        countLabel.text = nil
+    }
+}
+
+extension CategorySummaryCell {
+    private func setLayout() {
+        [titleLabel, countLabel, countUnitLabel, chevronImageView, midCategoryView, subCategoryView].forEach { contentView.addSubview($0) }
+        titleLabel.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().offset(12)
+        }
+        countLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
+            $0.leading.equalToSuperview().offset(12)
+        }
+        countUnitLabel.snp.makeConstraints {
+            $0.leading.equalTo(countLabel.snp.trailing)
+            $0.bottom.equalTo(countLabel.snp.bottom).offset(-4)
+        }
+        chevronImageView.snp.makeConstraints {
+            $0.trailing.equalToSuperview().offset(-8)
+            $0.top.equalToSuperview().offset(35)
+            $0.size.equalTo(24)
+        }
+        midCategoryView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(8)
+            $0.bottom.equalToSuperview().offset(-8)
+            $0.width.equalToSuperview().multipliedBy(0.44)
+            $0.height.equalTo(51)
+        }
+        subCategoryView.snp.makeConstraints {
+            $0.trailing.equalToSuperview().offset(-8)
+            $0.bottom.equalToSuperview().offset(-8)
+            $0.width.equalToSuperview().multipliedBy(0.44)
+            $0.height.equalTo(51)
+        }
+    }
+}
+
+extension CategorySummaryCell {
+    func config(name: String, totalCount: Int, midCount: Int, subCount: Int) {
+        titleLabel.text = name
+        countLabel.text = "\(totalCount)"
+        midCategoryView.config(count: midCount)
+        subCategoryView.config(count: subCount)
+    }
+}

--- a/JaengYeo/JaengYeo/View/Home/Cell/CategorySummaryCell.swift
+++ b/JaengYeo/JaengYeo/View/Home/Cell/CategorySummaryCell.swift
@@ -1,0 +1,8 @@
+//
+//  CategorySummaryCell.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/15/26.
+//
+
+import Foundation

--- a/JaengYeo/JaengYeo/View/Home/HomeSectionHeaderView.swift
+++ b/JaengYeo/JaengYeo/View/Home/HomeSectionHeaderView.swift
@@ -1,0 +1,38 @@
+//
+//  HomeSectionHeaderView.swift
+//  JaengYeo
+//
+//  Created by 손영빈 on 4/15/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class HomeSectionHeaderView: UICollectionReusableView {
+    static let id = "HomeSectionHeaderView"
+    
+    private let titleLabel = UILabel().then {
+        $0.font = LabelConfiguration.titleSemi16.font
+        $0.textColor = .gray800
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.top.bottom.equalToSuperview().inset(8)
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension HomeSectionHeaderView {
+    func config(title: String) {
+        titleLabel.text = title
+    }
+}

--- a/JaengYeo/JaengYeo/View/Home/HomeView.swift
+++ b/JaengYeo/JaengYeo/View/Home/HomeView.swift
@@ -73,7 +73,9 @@ extension HomeView {
                 return self.makeListUnclassifiedSection()
             case .categorySummary:
                 return self.makeCategorySummarySection()
-            default:
+            case .statusAlert, .recentItems:
+                return self.makeListUnclassifiedSection()
+            case .none:
                 return self.makeListUnclassifiedSection()
             }
         }

--- a/JaengYeo/JaengYeo/View/Home/HomeView.swift
+++ b/JaengYeo/JaengYeo/View/Home/HomeView.swift
@@ -29,12 +29,19 @@ enum HomeSection: Int, CaseIterable {
     }
 }
 
+enum HomeItem: Hashable {
+    case unclassified(Int)
+    case categorySummary(HomeViewModel.CategorySummary)
+}
+
 final class HomeView: UIView {
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout()).then {
         $0.backgroundColor = .white
         $0.showsVerticalScrollIndicator = false
         $0.register(UnclassifiedCell.self, forCellWithReuseIdentifier: UnclassifiedCell.id)
+        $0.register(CategorySummaryCell.self, forCellWithReuseIdentifier: CategorySummaryCell.id)
+        $0.register(HomeSectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HomeSectionHeaderView.id)
     }
     
     override init(frame: CGRect) {
@@ -64,6 +71,8 @@ extension HomeView {
             switch section {
             case .unclassified:
                 return self.makeListUnclassifiedSection()
+            case .categorySummary:
+                return self.makeCategorySummarySection()
             default:
                 return self.makeListUnclassifiedSection()
             }
@@ -73,13 +82,29 @@ extension HomeView {
 
 extension HomeView {
     private func makeListUnclassifiedSection() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(67))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(67))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(67))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(67))
         let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 16, trailing: 16)
         section.interGroupSpacing = 8
+        return section
+    }
+    
+    private func makeCategorySummarySection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .absolute(133))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(133))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        group.interItemSpacing = .fixed(8)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 16, trailing: 16)
+        
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(32))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
+        section.boundarySupplementaryItems = [header]
         return section
     }
 }

--- a/JaengYeo/JaengYeo/View/Home/HomeViewController.swift
+++ b/JaengYeo/JaengYeo/View/Home/HomeViewController.swift
@@ -15,7 +15,7 @@ final class HomeViewController: UIViewController {
     private let viewModel: HomeViewModel
     
     private let mainView = HomeView()
-    private var dataSource: UICollectionViewDiffableDataSource<HomeSection, Int>?
+    private var dataSource: UICollectionViewDiffableDataSource<HomeSection, HomeItem>?
     
     private let viewWillAppearRelay = PublishRelay<Void>()
     
@@ -46,18 +46,28 @@ final class HomeViewController: UIViewController {
 
 extension HomeViewController {
     private func bind() {
+        
+        let categoryCardTapped = mainView.collectionView.rx.itemSelected
+            .filter { $0.section == HomeSection.categorySummary.rawValue }
+            .compactMap { [weak self] indexPath -> String? in
+                guard case .categorySummary(let summary) = self?.dataSource?.itemIdentifier(for: indexPath) else { return nil }
+                return summary.name
+            }
+            .asObservable()
+        
         let input = HomeViewModel.Input(
             viewWillAppear: viewWillAppearRelay.asObservable(),
             unclassifiedTapped: mainView.collectionView.rx.itemSelected
                 .filter { $0.section == HomeSection.unclassified.rawValue }
-                .map { _ in }
+                .map { _ in },
+            categoryCardTapped: categoryCardTapped
         )
         let output = viewModel.transform(input)
         
-        output.unclassifiedCount
+        Observable.combineLatest(output.unclassifiedCount, output.categorySummaries)
             .observe(on: MainScheduler.instance)
-            .bind(onNext: { [weak self] count in
-                self?.setSnapshot(unclassifiedCount: count)
+            .bind(onNext: { [weak self] count, summaries in
+                self?.setSnapshot(unclassifiedCount: count, categorySummaries: summaries)
             })
             .disposed(by: disposeBag)
     }
@@ -66,19 +76,36 @@ extension HomeViewController {
 extension HomeViewController {
     private func configDataSource() {
         dataSource = UICollectionViewDiffableDataSource(collectionView: mainView.collectionView) { collectionView, indexPath, itemIdentifier in
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UnclassifiedCell.id, for: indexPath) as? UnclassifiedCell else { return UICollectionViewCell() }
-            cell.config(count: itemIdentifier)
-            return cell
+            switch itemIdentifier {
+            case .unclassified(let count):
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UnclassifiedCell.id, for: indexPath) as? UnclassifiedCell else { return UICollectionViewCell() }
+                cell.config(count: count)
+                return cell
+            case .categorySummary(let summary):
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategorySummaryCell.id, for: indexPath) as? CategorySummaryCell else { return UICollectionViewCell() }
+                cell.config(name: summary.name, totalCount: summary.totalCount, midCount: summary.midCategoryCount, subCount: summary.subCategoryCount)
+                return cell
+            }
+        }
+        dataSource?.supplementaryViewProvider = { collectionView, kind, indexPath in
+            guard kind == UICollectionView.elementKindSectionHeader,
+                  let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: HomeSectionHeaderView.id, for: indexPath) as? HomeSectionHeaderView else { return UICollectionReusableView() }
+            header.config(title: HomeSection(rawValue: indexPath.section)?.title ?? "")
+            return header
         }
     }
 }
 
 extension HomeViewController {
-    private func setSnapshot(unclassifiedCount: Int) {
-        var snapshot = NSDiffableDataSourceSnapshot<HomeSection, Int>()
+    private func setSnapshot(unclassifiedCount: Int, categorySummaries: [HomeViewModel.CategorySummary]) {
+        var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
         if unclassifiedCount > 0 {
             snapshot.appendSections([.unclassified])
-            snapshot.appendItems([unclassifiedCount], toSection: .unclassified)
+            snapshot.appendItems([.unclassified(unclassifiedCount)], toSection: .unclassified)
+        }
+        if !categorySummaries.isEmpty {
+            snapshot.appendSections([.categorySummary])
+            snapshot.appendItems(categorySummaries.map { .categorySummary($0) }, toSection: .categorySummary)
         }
         dataSource?.apply(snapshot, animatingDifferences: false)
     }

--- a/JaengYeo/JaengYeo/View/Home/HomeViewController.swift
+++ b/JaengYeo/JaengYeo/View/Home/HomeViewController.swift
@@ -22,6 +22,7 @@ final class HomeViewController: UIViewController {
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        overrideUserInterfaceStyle = .light
     }
     
     required init?(coder: NSCoder) {

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -230,3 +230,13 @@ private extension StockViewController {
         }
     }
 }
+
+// Home에서 세그먼트 변경 후 접근할 메서드
+extension StockViewController {
+    func selectMainCategory(name: String) {
+        guard let index = (0..<mainCategorySegment.numberOfSegments)
+            .first(where: { mainCategorySegment.titleForSegment(at: $0) == name }) else { return }
+        mainCategorySegment.selectedSegmentIndex = index
+        mainCategorySegment.sendActions(for: .valueChanged)
+    }
+}

--- a/JaengYeo/JaengYeo/ViewModel/HomeViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/HomeViewModel.swift
@@ -11,10 +11,19 @@ import RxCocoa
 
 final class HomeViewModel: ViewModelProtocol {
     
+    // 전체 현황에서 사용할 데이터 모델 구조체
+    struct CategorySummary: Hashable {
+        let name: String
+        let totalCount: Int
+        let midCategoryCount: Int
+        let subCategoryCount: Int
+    }
+    
     private let disposeBag = DisposeBag()
     private let coreDataManager: CoreDataManagerProtocol
     
     let navigateToUnclassified = PublishSubject<Void>()
+    let navigateToCategory = PublishSubject<String>()
     
     init(coreDataManager: CoreDataManagerProtocol) {
         self.coreDataManager = coreDataManager
@@ -23,14 +32,19 @@ final class HomeViewModel: ViewModelProtocol {
     struct Input {
         let viewWillAppear: Observable<Void>
         let unclassifiedTapped: Observable<Void>
+        let categoryCardTapped: Observable<String>
     }
     
     struct Output {
         let unclassifiedCount: Observable<Int>
+        let categorySummaries: Observable<[CategorySummary]>
     }
     
     func transform(_ input: Input) -> Output {
-        let unclassifiedCount = input.viewWillAppear
+        // viewWillAppear 동시에 구독: share()
+        let trigger = input.viewWillAppear.share()
+        
+        let unclassifiedCount = trigger
             .map { [weak self] _ -> Int in
                 guard let self else { return 0 }
                 do {
@@ -40,10 +54,42 @@ final class HomeViewModel: ViewModelProtocol {
                 }
             }
         
+        let categorySummaries = trigger
+            .map { [weak self] _ -> [CategorySummary] in
+                guard let self else { return [] }
+                do {
+                    let food = try self.coreDataManager.fetchByMainCategory(mainCategory: "식재료")
+                    let household = try self.coreDataManager.fetchByMainCategory(mainCategory: "생활용품")
+                    return[
+                        CategorySummary(
+                            name: "식재료",
+                            totalCount: food.count,
+                            midCategoryCount: Set(food.compactMap { $0.midCategoryId}).count,
+                            subCategoryCount: Set(food.compactMap { $0.subCategoryId}).count
+                        ),
+                        CategorySummary(
+                            name: "생활용품",
+                            totalCount: household.count,
+                            midCategoryCount: Set(household.compactMap { $0.midCategoryId }).count,
+                            subCategoryCount: Set(household.compactMap { $0.subCategoryId }).count
+                        )
+                    ]
+                } catch {
+                    return []
+                }
+            }
+        
         input.unclassifiedTapped
             .bind(to: navigateToUnclassified)
             .disposed(by: disposeBag)
         
-        return Output(unclassifiedCount: unclassifiedCount)
+        input.categoryCardTapped
+            .bind(to: navigateToCategory)
+            .disposed(by: disposeBag)
+        
+        return Output(
+            unclassifiedCount: unclassifiedCount,
+            categorySummaries: categorySummaries
+        )
     }
 }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #

## 🛠 작업 내용 (What I did)
- HomeSectionHeaderView, CategorySummaryCell, CategorySubCard 구현
- HomeView, HomeViewModel, HomeViewController 구현
- StockViewController: selectMainCategory 메서드 추가( SummaryCell 클릭 시 카테고리 기준 접근 기능)
- tabBarController 직접 접근 -> Coordinator를 통해 탭 전환으로 구현, 기존 RegisterCoordinator 수정

## 💻 구현 상세 (Implementation Details)
- 기존 RegisterCoordinator에서 tabBarController를 이용해서 탭 전환하던 방식을 Coordinator를 통해 거치도록 수정
- CardCell 클릭 시 탭 전환도 동일하게 Coordinator를 통해 변경
- DiffableDataSource: 미분류 셀과 카테고리 요약 셀 모두. ㅘㄴ리하기 위해 HomeItem enum 생성

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?