### PR TITLE
[FEAT] 검색 #18

### DIFF
--- a/JaengYeo/JaengYeo/Application/StockCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/StockCoordinator.swift
@@ -40,6 +40,13 @@ extension StockCoordinator: StockViewControllerDelegate {
         categoryEditViewController.delegate = self
         navigationController.pushViewController(categoryEditViewController, animated: true)
     }
+    
+    func didTapSearchButton() {
+        let viewController = StockSearchViewController(
+            viewModel: StockSearchViewModel(coreDataManager: coreDataManager)
+        )
+        navigationController.pushViewController(viewController, animated: true)
+    }
 }
 
 extension StockCoordinator: CategoryEditViewControllerDelegate {

--- a/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
@@ -1,0 +1,246 @@
+//
+//  StockSearchViewController.swift
+//  JaengYeo
+//
+//  Created by Codex on 4/15/26.
+//
+
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+import UIKit
+
+final class StockSearchViewController: UIViewController {
+
+    //MARK: - Enum
+    private enum Section {
+        case main
+    }
+
+    //MARK: - ViewModel
+    private let viewModel: StockSearchViewModel
+
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private lazy var dataSource = configureDataSource()
+
+    //MARK: - Components
+    /// 뒤로가기 버튼
+    private let backButton = UIButton(type: .custom).then {
+        let image = UIImage(named: "liquidArrowIcon")
+        $0.setImage(image, for: .normal)
+        $0.tintColor = .white
+    }
+
+    /// 검색바
+    private let searchBar = UISearchBar().then {
+        $0.placeholder = "키워드 입력"
+        $0.searchBarStyle = .minimal
+        $0.returnKeyType = .search
+        $0.backgroundImage = UIImage()
+        $0.barTintColor = .clear
+        $0.backgroundColor = .white
+        $0.tintColor = .gray800
+        
+        let textField = $0.searchTextField
+        textField.backgroundColor = .gray50
+        textField.font = LabelConfiguration.bodyMedium12.font
+        textField.layer.cornerRadius = 22
+        textField.layer.masksToBounds = true
+        textField.borderStyle = .none
+    }
+
+    /// 검색 결과 컬렉션 뷰
+    private lazy var collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: createLayout()
+    ).then {
+        $0.backgroundColor = .white
+        $0.keyboardDismissMode = .onDrag
+    }
+
+    //MARK: - Init
+    init(viewModel: StockSearchViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        overrideUserInterfaceStyle = .light
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        bind()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        searchBar.becomeFirstResponder()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+}
+
+//MARK: - Binding
+private extension StockSearchViewController {
+    func bind() {
+        let input = StockSearchViewModel.Input(
+            viewDidLoad: Observable.just(()),
+            searchText: searchBar.rx.text.orEmpty
+                .debounce(.milliseconds(200), scheduler: MainScheduler.instance)
+                .distinctUntilChanged()
+                .asObservable()
+        )
+
+        let output = viewModel.transform(input)
+
+        output.products
+            .bind(onNext: { [weak self] products in
+                self?.applySnapshot(with: products)
+            })
+            .disposed(by: disposeBag)
+
+        backButton.rx.tap
+            .bind(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - DataSource
+private extension StockSearchViewController {
+    
+    /// 스냅샷
+    func applySnapshot(with products: [ProductCellItem]) {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ProductCellItem>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(products, toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+    
+    /// 데이터소스 설정
+    private func configureDataSource() -> UICollectionViewDiffableDataSource<
+        Section,
+        ProductCellItem
+    > {
+        let cellRegistration = UICollectionView.CellRegistration<
+            ProductCell,
+            ProductCellItem
+        > { cell, _, item in
+            var freshness: Int? = nil
+            if let expiryDate = item.product.expiryDate {
+                freshness = Calendar.current.dateComponents(
+                    [.day],
+                    from: Date(),
+                    to: expiryDate
+                ).day
+            }
+
+            let descriptions = [
+                item.midCategory,
+                item.subCategory
+            ].compactMap { $0 }
+
+            cell.updateUI(
+                type: .homeType,
+                title: item.product.name,
+                freshness: freshness,
+                descriptions: descriptions,
+                subdescriptions: nil,
+                count: item.product.quantity,
+                image: nil
+            )
+        }
+
+        return UICollectionViewDiffableDataSource<Section, ProductCellItem>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, item in
+            collectionView.dequeueConfiguredReusableCell(
+                using: cellRegistration,
+                for: indexPath,
+                item: item
+            )
+        }
+    }
+}
+
+//MARK: - Compositional Layout
+private extension StockSearchViewController {
+    /// 컬렉션 뷰 레이아웃 생성
+    func createLayout() -> UICollectionViewLayout {
+        let item = NSCollectionLayoutItem(
+            layoutSize: .init(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(88)
+            )
+        )
+
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: .init(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(88)
+            ),
+            subitems: [item]
+        )
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 8
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 8,
+            leading: 16,
+            bottom: 0,
+            trailing: 16
+        )
+
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+}
+
+//MARK: - Configure UI
+private extension StockSearchViewController {
+    /// UI 설정
+    func configureUI() {
+        view.backgroundColor = .white
+
+        view.addSubview(backButton)
+        view.addSubview(searchBar)
+        view.addSubview(collectionView)
+
+        backButton.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(0)
+            $0.leading.equalToSuperview().offset(16)
+            $0.size.equalTo(54)
+        }
+
+        searchBar.snp.makeConstraints {
+            $0.centerY.equalTo(backButton.snp.centerY)
+            $0.leading.equalTo(backButton.snp.trailing).offset(8)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(44)
+        }
+
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom).offset(12)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+}
+
+#Preview {
+    StockSearchViewController(
+        viewModel: StockSearchViewModel(coreDataManager: CoreDataManager())
+    )
+}

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -14,6 +14,7 @@ import UIKit
 
 protocol StockViewControllerDelegate: AnyObject {
     func didTapCategoryEditButton()
+    func didTapSearchButton()
 }
 
 final class StockViewController: UIViewController {
@@ -40,6 +41,7 @@ final class StockViewController: UIViewController {
         $0.setTitleTextAttributes(selectAttributes, for: .selected)
 
         $0.selectedSegmentTintColor = .white
+        $0.backgroundColor = .gray50
     }
 
     private let categoryFilterView = CategoryFilterView()
@@ -177,6 +179,7 @@ private extension StockViewController {
 private extension StockViewController {
     @objc
     private func didTapSearchButton() {
+        delegate?.didTapSearchButton()
     }
     
     /// 카테고리 선택 모달 표시
@@ -233,7 +236,7 @@ private extension StockViewController {
             $0.top.equalTo(mainCategorySegment.snp.bottom).offset(8)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(46)
+            $0.height.equalTo(40)
         }
         productCollectionView.snp.makeConstraints {
             $0.top.equalTo(categoryFilterView.snp.bottom).offset(8)

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
@@ -196,7 +196,7 @@ extension StockSearchViewModel: NSFetchedResultsControllerDelegate {
         do {
             try productFetchResultController?.performFetch()
         } catch {
-            print("StockSearchViewModel performFetch error: \(error)")
+
         }
     }
 

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
@@ -1,0 +1,253 @@
+//
+//  StockSearchViewModel.swift
+//  JaengYeo
+//
+//  Created by Codex on 4/15/26.
+//
+
+import CoreData
+import Foundation
+import RxRelay
+import RxSwift
+
+final class StockSearchViewModel: NSObject, ViewModelProtocol {
+
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private let coreDataManager: CoreDataManagerProtocol
+
+    /// 검색 결과로 보여줄 상품 셀 아이템 목록
+    private let productsRelay = BehaviorRelay<[ProductCellItem]>(value: [])
+
+    /// 마지막으로 입력된 검색어 저장
+    private let latestKeywordRelay = BehaviorRelay<String>(value: "")
+
+    /// 상품 변경 사항을 감지하기 위한 FetchedResultsController
+    private var productFetchResultController: NSFetchedResultsController<ProductEntity>?
+
+    /// 중분류 ID -> 이름 매핑 캐시
+    private lazy var midCategoryNames: [UUID: String] = fetchMidCategoryNames()
+
+    /// 소분류 ID -> 이름 매핑 캐시
+    private lazy var subCategoryNames: [UUID: String] = fetchSubCategoryNames()
+
+    //MARK: - React Binding
+    struct Input {
+        /// 화면 진입 시점 이벤트
+        let viewDidLoad: Observable<Void>
+
+        /// 검색어 입력 이벤트
+        let searchText: Observable<String>
+    }
+
+    struct Output {
+        /// 검색 결과 상품 목록
+        let products: Observable<[ProductCellItem]>
+    }
+
+    func transform(_ input: Input) -> Output {
+        input.viewDidLoad
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.configureProductResultController()
+                self.midCategoryNames = fetchMidCategoryNames()
+                self.subCategoryNames = fetchSubCategoryNames()
+                self.performFetch()
+            })
+            .disposed(by: disposeBag)
+
+        input.searchText
+            .distinctUntilChanged()
+            .subscribe(onNext: { [weak self] text in
+                /// 현재 검색어 저장
+                self?.latestKeywordRelay.accept(text)
+
+                /// 검색어 기준으로 결과 갱신
+                self?.updateProduct(keyword: text)
+            })
+            .disposed(by: disposeBag)
+
+        return Output(
+            products: productsRelay.asObservable()
+        )
+    }
+
+    //MARK: - Init
+    init(coreDataManager: CoreDataManagerProtocol) {
+        self.coreDataManager = coreDataManager
+        super.init()
+    }
+}
+
+//MARK: - FRC
+extension StockSearchViewModel: NSFetchedResultsControllerDelegate {
+    /// 상품 FRC 구성
+    /// 여기서는 fetchRequest와 delegate만 연결하고,
+    /// 실제 데이터 조회는 performFetch()에서 수행
+    private func configureProductResultController() {
+        let request = ProductEntity.fetchRequest()
+        request.sortDescriptors = [
+            NSSortDescriptor(
+                key: ProductEntity.Keys.createdAt,
+                ascending: false
+            )
+        ]
+
+        let controller = NSFetchedResultsController(
+            fetchRequest: request,
+            managedObjectContext: coreDataManager.context,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
+
+        controller.delegate = self
+        productFetchResultController = controller
+    }
+
+    /// 검색어 기준으로 상품 목록 갱신
+    ///
+    /// 우선순위:
+    /// 1. 상품명(name)에 검색어 포함
+    /// 2. 중분류명(midCategory)에 검색어 포함
+    /// 3. 소분류명(subCategory)에 검색어 포함
+    private func updateProduct(keyword: String) {
+        let trimmedkeyword = keyword.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+
+        /// 빈 검색어면 결과 비움
+        guard !trimmedkeyword.isEmpty else {
+            productsRelay.accept([])
+            return
+        }
+
+        /// 공백 제거 + 소문자 변환한 검색어
+        let normalizedKeyword = normalizedSearchText(trimmedkeyword)
+
+        let products: [ProductCellItem] = productFetchResultController?
+            .fetchedObjects?
+            .compactMap { entity -> (priority: Int, item: ProductCellItem)? in
+                let product = entity.toDomain
+
+                /// 상품에 연결된 중분류/소분류 이름 조회
+                let midCategoryName = product.midCategoryId.flatMap {
+                    midCategoryNames[$0]
+                }
+                let subCategoryName = product.subCategoryId.flatMap {
+                    subCategoryNames[$0]
+                }
+
+                /// 비교용 문자열 정규화
+                let normalizedName = normalizedSearchText(product.name)
+                let normalizedMid = midCategoryName.map {
+                    normalizedSearchText($0)
+                }
+                let normalizedSub = subCategoryName.map {
+                    normalizedSearchText($0)
+                }
+
+                /// 우선순위별 매칭 여부 확인
+                let nameMatch = normalizedName.contains(normalizedKeyword)
+                let midMatch =
+                    normalizedMid?.contains(normalizedKeyword) ?? false
+                let subMatch =
+                    normalizedSub?.contains(normalizedKeyword) ?? false
+
+                /// 매칭 우선순위 결정
+                /// 상품명 > 중분류 > 소분류 순
+                let priority: Int?
+                if nameMatch {
+                    priority = 0
+                } else if midMatch {
+                    priority = 1
+                } else if subMatch {
+                    priority = 2
+                } else {
+                    priority = nil
+                }
+
+                /// 어떤 조건에도 맞지 않으면 결과 제외
+                guard let priority else { return nil }
+
+                let item = ProductCellItem(
+                    product: product,
+                    midCategory: midCategoryName,
+                    subCategory: subCategoryName
+                )
+
+                return (priority, item)
+            }
+            .sorted {
+                /// 우선순위 오름차순 정렬
+                if $0.priority !=  $1.priority {
+                    return $0.priority < $1.priority
+                }
+
+                /// 같은 우선순위 내에서는 최신 등록순 정렬
+                return $0.item.product.createdAt > $1.item.product.createdAt
+            }
+            .map { $0.item } ?? []
+
+        productsRelay.accept(products)
+    }
+
+    /// fetch 수행
+    private func performFetch() {
+        do {
+            try productFetchResultController?.performFetch()
+        } catch {
+            print("StockSearchViewModel performFetch error: \(error)")
+        }
+    }
+
+    /// CoreData 변경 감지 시 호출
+    /// 상세 화면에서 상품 수정 후 저장되면 여기로 들어올 수 있음
+    func controllerDidChangeContent(
+        _ controller: NSFetchedResultsController<NSFetchRequestResult>
+    ) {
+        /// 마지막 검색어 기준으로 다시 필터링
+        updateProduct(keyword: latestKeywordRelay.value)
+    }
+}
+
+//MARK: - Action
+extension StockSearchViewModel {
+    /// 문자열 정규화
+    private func normalizedSearchText(_ text: String) -> String {
+        text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .joined()
+            .lowercased()
+    }
+}
+
+//MARK: - CoreData
+extension StockSearchViewModel {
+    /// 중분류 이름 조회
+    private func fetchMidCategoryNames() -> [UUID: String] {
+        let request = MidCategoryEntity.fetchRequest()
+
+        do {
+            return try coreDataManager.context.fetch(request)
+                .reduce(into: [UUID: String]()) {
+                    $0[$1.id] = $1.name
+                }
+        } catch {
+            return [:]
+        }
+    }
+
+    /// 소분류 이름 조회
+    private func fetchSubCategoryNames() -> [UUID: String] {
+        let request = SubCategoryEntity.fetchRequest()
+
+        do {
+            return try coreDataManager.context.fetch(request)
+                .reduce(into: [UUID: String]()) {
+                    $0[$1.id] = $1.name
+                }
+        } catch {
+            return [:]
+        }
+    }
+}

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
@@ -205,6 +205,10 @@ extension StockSearchViewModel: NSFetchedResultsControllerDelegate {
     func controllerDidChangeContent(
         _ controller: NSFetchedResultsController<NSFetchRequestResult>
     ) {
+        /// 카테고리 캐시 갱신
+        self.midCategoryNames = fetchMidCategoryNames()
+        self.subCategoryNames = fetchSubCategoryNames()
+
         /// 마지막 검색어 기준으로 다시 필터링
         updateProduct(keyword: latestKeywordRelay.value)
     }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #18

##  🛠 작업 내용 (What I did)
- 재고 검색 화면 설계 및 제작
- NSFetchedResultsController 기반 상품 감지 구조 적용
- 상품명 / 중분류 / 소분류 통합 검색 구현
- 상품명 > 중분류 > 소분류 우선순위 정렬 적용
- 공백/대소문자 무시 검색 처리
- 상세 수정 후 복귀 시 검색 결과 자동 반영

## 💻 구현 상세 (Implementation Details)
- StockSearchViewController 추가
- UISearchBar 적용
- snapshot 기반 목록 갱신
- StockSearchViewModel
- NSFetchedResultsController 구성 및 fetch 수행
- 중분류/소분류 이름 캐시 매핑
- 문자열 정규화 후 검색 비교
- 우선순위 기반 결과 정렬

## 📸 스크린샷 (Screenshots)
https://github.com/user-attachments/assets/328d152c-328b-42b5-a3d4-652b2afc045d

