### PR TITLE
[FEAT] 상세 진입 #21

### DIFF
--- a/JaengYeo/JaengYeo/Application/StockCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/StockCoordinator.swift
@@ -47,6 +47,16 @@ extension StockCoordinator: StockViewControllerDelegate {
         )
         navigationController.pushViewController(viewController, animated: true)
     }
+    
+    func didSelectProduct(productID: UUID) {
+        let viewController = ProductDetailViewController(
+            viewModel: ProductDetailViewModel(
+                productID: productID,
+                coreDataManager: coreDataManager
+            )
+        )
+        navigationController.pushViewController(viewController, animated: true)
+    }
 }
 
 extension StockCoordinator: CategoryEditViewControllerDelegate {

--- a/JaengYeo/JaengYeo/Data/CoreData/MidCategoryEntity+CoreDataProperties.swift
+++ b/JaengYeo/JaengYeo/Data/CoreData/MidCategoryEntity+CoreDataProperties.swift
@@ -33,3 +33,19 @@ extension MidCategoryEntity {
 extension MidCategoryEntity : Identifiable {
 
 }
+
+extension MidCategoryEntity {
+    var toDomain: MidCategory {
+        MidCategory(
+            id: id,
+            userId: userId.flatMap { UUID(uuidString: $0) },
+            mainCategory: mainCategory,
+            name: name,
+            iconName: iconName,
+            sortOrder: Int(sortOrder),
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            syncStatus: syncStatus
+        )
+    }
+}

--- a/JaengYeo/JaengYeo/Data/CoreData/SubCategoryEntity+CoreDataProperties.swift
+++ b/JaengYeo/JaengYeo/Data/CoreData/SubCategoryEntity+CoreDataProperties.swift
@@ -33,3 +33,20 @@ extension SubCategoryEntity {
 extension SubCategoryEntity : Identifiable {
 
 }
+
+extension SubCategoryEntity {
+    var toDomain: SubCategory {
+        SubCategory(
+            id: id,
+            userId: userId.flatMap { UUID(uuidString: $0) },
+            mainCategory: mainCategory,
+            name: name,
+            iconName: iconName,
+            thumbnailKey: thumbnailKey,
+            sortOrder: Int(sortOrder),
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            syncStatus: syncStatus
+        )
+    }
+}

--- a/JaengYeo/JaengYeo/Utils/Configuration/CategoryIconName.swift
+++ b/JaengYeo/JaengYeo/Utils/Configuration/CategoryIconName.swift
@@ -27,6 +27,19 @@ enum HouseholdSubCategoryIcon: String, CaseIterable {
     case defaultIcon = "categoryIcon"
 }
 
+enum ProductInfoIcon: String, CaseIterable {
+    case nameIcon = "nameIcon"
+    case purchaseDateIcon = "calendarIcon"
+    case mainCategoryIcon = "categoryIcon"
+    case midCategoryIcon = "locationIcon"
+    case subCategoryIcon = "filterIcon"
+    case expiryDateIcon = "timeIcon"
+    case cautionIcon = "warningIcon"
+    case brandIcon = "bagIcon"
+    case lowStockThresholdIcon = "alarmIcon"
+    case memoIcon = "imageIcon"
+}
+
 //MARK: - Method
 extension CaseIterable where Self: RawRepresentable, RawValue == String {
     /// 아이콘 이름 목록

--- a/JaengYeo/JaengYeo/Utils/Image/ImageUtils.swift
+++ b/JaengYeo/JaengYeo/Utils/Image/ImageUtils.swift
@@ -1,0 +1,38 @@
+//
+//  ImageUtils.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 4/16/26.
+//
+
+import Foundation
+import UIKit
+
+enum ImageUtils {
+    static func saveImage(_ image: UIImage) -> String? {
+        guard let data = image.jpegData(compressionQuality: 0.8) else { return nil }
+
+        let fileName = UUID().uuidString + ".jpg"
+        let url = FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(fileName)
+
+        do {
+            try data.write(to: url)
+            return fileName
+        } catch {
+            return nil
+        }
+    }
+    
+    static func loadImage(fileName: String?) -> UIImage? {
+        guard let fileName else { return nil }
+
+        let url = FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(fileName)
+
+        return UIImage(contentsOfFile: url.path)
+    }
+
+}

--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -213,11 +213,11 @@ private extension ProductCell {
                 config: .body12.updatingColor(color: .primaryRed)
             ).then {
                 if freshness > 0 {
-                    "\(freshness)일 남음"
+                    $0.text =  "\(freshness)일 남음"
                 } else if freshness == 0 {
-                    "오늘 만료"
+                    $0.text =  "오늘 만료"
                 } else {
-                    "유통기한 만료"
+                    $0.text =  "유통기한 만료"
                 }
                 $0.numberOfLines = 1
             }

--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -212,7 +212,13 @@ private extension ProductCell {
             let freshnessLabel = StyledLabel(
                 config: .body12.updatingColor(color: .primaryRed)
             ).then {
-                $0.text = freshness > 0 ? "\(freshness)일 남음" : "소비기한 만료"
+                if freshness > 0 {
+                    "\(freshness)일 남음"
+                } else if freshness == 0 {
+                    "오늘 만료"
+                } else {
+                    "유통기한 만료"
+                }
                 $0.numberOfLines = 1
             }
             labels.append(freshnessLabel)

--- a/JaengYeo/JaengYeo/View/Stock/CategoryEditDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategoryEditDetailViewController.swift
@@ -229,12 +229,12 @@ private extension CategoryEditDetailViewController {
         
         viewController.onApply = { [weak self] iconName in
             guard let self else { return }
-            self.selectedIconName = iconName
+            self.selectedIconName = iconName 
             self.categoryImageView.image = UIImage(named: iconName)
             self.iconNameSelectedRelay.accept(iconName)
         }
         
-        present(viewController, animated: true)
+        present(viewController, animated: false)
     }
 }
 

--- a/JaengYeo/JaengYeo/View/Stock/CategoryIconsView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategoryIconsView.swift
@@ -24,6 +24,25 @@ final class CategoryIconsView: UIView {
     private lazy var dataSource = configureDataSource()
 
     //MARK: - Components
+    /// 바텀 시트 시 뒷 배경
+    let dimmingView = UIView().then {
+        $0.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        $0.alpha = 0
+    }
+    
+    /// 상단 핸들 뷰
+    let handleView = UIView().then {
+        $0.backgroundColor = .gray300
+        $0.layer.cornerRadius = 2.5
+    }
+    
+    let contentView = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 20
+        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        $0.clipsToBounds = true
+    }
+    
     /// 카테고리 컬렉션 뷰
     lazy var collectionView = UICollectionView(
         frame: .zero,
@@ -160,27 +179,42 @@ private extension CategoryIconsView {
 private extension CategoryIconsView {
     /// UI 설정
     private func configureUI() {
-        backgroundColor = .white
-        layer.cornerRadius = 8
-        layer.maskedCorners = [
-            .layerMinXMinYCorner,
-            .layerMaxXMinYCorner
-        ]
-        clipsToBounds = true
+        backgroundColor = .clear
 
-        addSubview(collectionView)
-        addSubview(applyButton)
+        addSubview(dimmingView)
+        addSubview(contentView)
+
+        contentView.addSubview(handleView)
+        contentView.addSubview(collectionView)
+        contentView.addSubview(applyButton)
+
+        dimmingView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        contentView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.greaterThanOrEqualToSuperview()
+        }
+
+        handleView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(8)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(40)
+            $0.height.equalTo(5)
+        }
 
         collectionView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalTo(handleView.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(applyButton.snp.top).offset(-16)
+            $0.height.equalTo(280)
         }
 
         applyButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalTo(safeAreaLayoutGuide).inset(16)
+            $0.bottom.equalTo(contentView.safeAreaLayoutGuide).inset(16)
             $0.height.equalTo(44)
         }
     }

--- a/JaengYeo/JaengYeo/View/Stock/CategoryIconsViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategoryIconsViewController.swift
@@ -13,14 +13,13 @@ import UIKit
 final class CategoryIconsViewController: UIViewController {
 
     //MARK: - Properties
-    private let iconsViewHeight = 356
     private let iconNames: [String]
     private let disposeBag = DisposeBag()
     private var selectedIconName: String?
     var onApply: ((String) -> Void)?
 
     //MARK: - Components
-    private let categoryIconsView = CategoryIconsView()
+    private let mainView = CategoryIconsView()
 
     //MARK: - Init
     init(
@@ -30,37 +29,54 @@ final class CategoryIconsViewController: UIViewController {
         self.iconNames = iconNames
         self.selectedIconName = selectedIconName
         super.init(nibName: nil, bundle: nil)
-        configurePresentation()
+        modalPresentationStyle = .overFullScreen
+        overrideUserInterfaceStyle = .light
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func loadView() {
+        self.view = mainView
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureNavigationBar()
-        configureUI()
         configureData()
         bind()
+        addPanGesture()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        animateIn()
     }
 }
 
 //MARK: - Bind
 private extension CategoryIconsViewController {
     func bind() {
-        /// 아이콘 선택
-        categoryIconsView.collectionView.rx.itemSelected
+        let dimmingTap = UITapGestureRecognizer()
+        mainView.dimmingView.addGestureRecognizer(dimmingTap)
+
+        dimmingTap.rx.event
+            .bind(onNext: { [weak self] _ in
+                guard let self else { return }
+                animateOut { self.dismiss(animated: false) }
+            })
+            .disposed(by: disposeBag)
+
+        mainView.collectionView.rx.itemSelected
             .compactMap { [weak self] indexPath in
-                self?.categoryIconsView.iconName(at: indexPath)
+                self?.mainView.iconName(at: indexPath)
             }
             .bind(onNext: { [weak self] iconName in
                 self?.selectIcon(named: iconName)
             })
             .disposed(by: disposeBag)
 
-        /// 완료 버튼 선택
-        categoryIconsView.applyButton.rx.tap
+        mainView.applyButton.rx.tap
             .bind(onNext: { [weak self] in
                 self?.applySelectedIcon()
             })
@@ -70,82 +86,119 @@ private extension CategoryIconsViewController {
 
 //MARK: - Action
 private extension CategoryIconsViewController {
-    /// 배경 선택 이벤트
-    @objc
-    func didTapBackground(_ gesture: UITapGestureRecognizer) {
-        let location = gesture.location(in: view)
-        
-        if !categoryIconsView.frame.contains(location) {
-            close()
-        }
-    }
-    
     /// 아이콘 선택
     func selectIcon(named iconName: String) {
         selectedIconName = iconName
     }
-    
+
     /// 선택 아이콘 적용
     func applySelectedIcon() {
         guard let selectedIconName else { return }
-        onApply?(selectedIconName)
-        close()
-    }
-    
-    /// 화면 닫기
-    func close() {
-        dismiss(animated: true)
+
+        let iconName = selectedIconName
+        animateOut { [weak self] in
+            self?.onApply?(iconName)
+            self?.dismiss(animated: false)
+        }
     }
 }
 
 //MARK: - Configure
 private extension CategoryIconsViewController {
-    /// 모달 설정
-    func configurePresentation() {
-        modalPresentationStyle = .overFullScreen
-        modalTransitionStyle = .coverVertical
-        overrideUserInterfaceStyle = .light
-    }
-    
-    /// 네비게이션 바 설정
-    func configureNavigationBar() {
-        title = "아이콘 선택"
-        navigationController?.navigationBar.tintColor = .gray800
-    }
-
     /// 데이터 설정
     func configureData() {
-        categoryIconsView.updateIcons(
+        mainView.updateIcons(
             iconNames: iconNames,
             selectedIconName: selectedIconName
         )
     }
+}
 
-    /// UI 설정
-    func configureUI() {
-        view.backgroundColor = .clear
-        view.overrideUserInterfaceStyle = .light
-        
-        let tapGesture = UITapGestureRecognizer(
-            target: self,
-            action: #selector(didTapBackground)
+//MARK: - Animation
+private extension CategoryIconsViewController {
+    /// 바텀 시트 생성
+    func animateIn() {
+        view.layoutIfNeeded()
+        let contentView = mainView.contentView
+        contentView.transform = CGAffineTransform(
+            translationX: 0,
+            y: contentView.bounds.height + 300
         )
-        tapGesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(tapGesture)
 
-        view.addSubview(categoryIconsView)
-
-        categoryIconsView.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalToSuperview()
-            $0.height.equalTo(iconsViewHeight)
+        UIView.animate(withDuration: 0.35, delay: 0, options: .curveEaseOut) {
+            self.mainView.dimmingView.alpha = 1
+            contentView.transform = .identity
         }
+    }
+
+    /// 바텀 시트 소멸
+    func animateOut(completion: @escaping () -> Void) {
+        view.layoutIfNeeded()
+        let contentView = mainView.contentView
+
+        UIView.animate(
+            withDuration: 0.3,
+            delay: 0,
+            options: .curveEaseIn,
+            animations: {
+                self.mainView.dimmingView.alpha = 0
+                contentView.transform = CGAffineTransform(
+                    translationX: 0,
+                    y: contentView.bounds.height + 300
+                )
+            },
+            completion: { _ in
+                completion()
+            }
+        )
     }
 }
 
-#Preview {
-    UINavigationController(
-        rootViewController: CategoryIconsViewController(
-            iconNames: FoodSubCategoryIcon.iconNames
+//MARK: - Pan Gesture
+private extension CategoryIconsViewController {
+    /// contentView에 pan gesture 추가
+    func addPanGesture() {
+        let pan = UIPanGestureRecognizer(
+            target: self,
+            action: #selector(handlePan(_:))
         )
-    )
+        pan.cancelsTouchesInView = false
+        mainView.contentView.addGestureRecognizer(pan)
+    }
+
+    /// gesture 상태에 따라 drag dismiss 적용
+    @objc
+    func handlePan(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: mainView.contentView)
+        let velocity = gesture.velocity(in: mainView.contentView)
+        let contentView = mainView.contentView
+        let contentHeight = contentView.bounds.height
+
+        switch gesture.state {
+        case .changed:
+            let offsetY = max(0, translation.y)
+            contentView.transform = CGAffineTransform(translationX: 0, y: offsetY)
+
+            let ratio = max(0, 1 - (offsetY / contentHeight))
+            mainView.dimmingView.alpha = ratio
+
+        case .ended, .cancelled:
+            if translation.y > contentHeight * 0.35 || velocity.y > 800 {
+                animateOut { self.dismiss(animated: false) }
+            } else {
+                UIView.animate(
+                    withDuration: 0.3,
+                    delay: 0,
+                    usingSpringWithDamping: 0.8,
+                    initialSpringVelocity: 0.5
+                ) {
+                    contentView.transform = .identity
+                    self.mainView.dimmingView.alpha = 1
+                }
+            }
+
+        default:
+            break
+        }
+    }
 }

--- a/JaengYeo/JaengYeo/View/Stock/CategorySelectionView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategorySelectionView.swift
@@ -15,6 +15,26 @@ final class CategorySelectionView: UIView {
     /// 페이지 영역 뷰
     private let pageContainerView = UIView()
 
+    /// 바텀 시트 시 뒷 배경
+    let dimmingView = UIView().then {
+        $0.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        $0.alpha = 0
+    }
+
+    /// 콘텐츠 컨테이너
+    let contentView = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 20
+        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        $0.clipsToBounds = true
+    }
+
+    /// 상단 핸들 뷰
+    let handleView = UIView().then {
+        $0.backgroundColor = .gray300
+        $0.layer.cornerRadius = 2.5
+    }
+    
     /// 카테고리 컬렉션 뷰
     lazy var collectionView = UICollectionView(
         frame: .zero,
@@ -134,50 +154,65 @@ private extension CategorySelectionView {
     /// UI 설정
     func configureUI() {
         overrideUserInterfaceStyle = .light
-        backgroundColor = .white
+        backgroundColor = .clear
         pageContainerView.backgroundColor = .white
         collectionView.backgroundColor = .white
-        layer.cornerRadius = 16
-        layer.maskedCorners = [
-            .layerMinXMinYCorner,
-            .layerMaxXMinYCorner
-        ]
-        clipsToBounds = true
-
-        addSubview(pageContainerView)
-        addSubview(pageControl)
-        addSubview(resetButton)
-        addSubview(applyButton)
-
+        
+        addSubview(dimmingView)
+        addSubview(contentView)
+        
+        contentView.addSubview(handleView)
+        contentView.addSubview(pageContainerView)
+        contentView.addSubview(pageControl)
+        contentView.addSubview(resetButton)
+        contentView.addSubview(applyButton)
+        
         pageContainerView.addSubview(collectionView)
-
+        
+        dimmingView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.greaterThanOrEqualToSuperview()
+        }
+        
+        handleView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(8)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(40)
+            $0.height.equalTo(5)
+        }
+        
         pageContainerView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(20)
+            $0.top.equalTo(handleView.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(244)
         }
-
+        
         pageControl.snp.makeConstraints {
             $0.top.equalTo(pageContainerView.snp.bottom).offset(4)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(20)
         }
-
+        
         collectionView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-
+        
         resetButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(16)
             $0.centerY.equalTo(applyButton)
             $0.width.equalTo(63)
             $0.height.equalTo(20)
         }
-
+        
         applyButton.snp.makeConstraints {
+            $0.top.equalTo(pageControl.snp.bottom).offset(16)
             $0.leading.greaterThanOrEqualTo(resetButton.snp.trailing).offset(42)
             $0.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalTo(safeAreaLayoutGuide).inset(16)
+            $0.bottom.equalTo(contentView.safeAreaLayoutGuide).inset(16)
             $0.width.greaterThanOrEqualTo(238)
             $0.height.equalTo(44)
         }

--- a/JaengYeo/JaengYeo/View/Stock/CategorySelectionViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategorySelectionViewController.swift
@@ -32,16 +32,13 @@ final class CategorySelectionViewController: UIViewController {
 
     //MARK: - Components
     /// 카테고리 선택 뷰
-    private let categorySelectionView = CategorySelectionView().then {
-        $0.backgroundColor = .white
-    }
+    private let categorySelectionView = CategorySelectionView()
 
     //MARK: - Init
     init(items: [CategorySelectionItem] = []) {
         self.viewModel = CategorySelectionViewModel(items: items)
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .overFullScreen
-        modalTransitionStyle = .coverVertical
         overrideUserInterfaceStyle = .light
     }
 
@@ -51,8 +48,17 @@ final class CategorySelectionViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
         bind()
+        addPanGesture()
+    }
+
+    override func loadView() {
+        self.view = categorySelectionView
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        animateIn()
     }
 }
 
@@ -60,7 +66,17 @@ final class CategorySelectionViewController: UIViewController {
 extension CategorySelectionViewController {
     fileprivate func bind() {
         let itemSelectionToggledRelay = PublishRelay<CategorySelectionItem>()
-
+        
+        let dimmingTap = UITapGestureRecognizer()
+        categorySelectionView.dimmingView.addGestureRecognizer(dimmingTap)
+        
+        dimmingTap.rx.event
+            .bind(onNext: { [weak self] _ in
+                guard let self else { return }
+                animateOut { self.dismiss(animated: false) }
+            })
+            .disposed(by: disposeBag)
+        
         /// 아이템 선택 이벤트
         categorySelectionView.collectionView.rx.itemSelected
             .do(onNext: { [weak self] indexPath in
@@ -74,12 +90,14 @@ extension CategorySelectionViewController {
             }
             .bind(to: itemSelectionToggledRelay)
             .disposed(by: disposeBag)
-
+        
         /// 페이지 변경 이벤트
         categorySelectionView.collectionView.rx.contentOffset
             .compactMap { [weak self] contentOffset -> Int? in
                 let collectionView = self?.categorySelectionView.collectionView
-                guard let collectionView, collectionView.bounds.width > 0 else { return nil }
+                guard let collectionView, collectionView.bounds.width > 0 else {
+                    return nil
+                }
                 return Int(round(contentOffset.x / collectionView.bounds.width))
             }
             .distinctUntilChanged()
@@ -87,7 +105,7 @@ extension CategorySelectionViewController {
                 self?.categorySelectionView.pageControl.currentPage = page
             })
             .disposed(by: disposeBag)
-
+        
         /// 페이지 컨트롤 이벤트
         categorySelectionView.pageControl.rx.controlEvent(.valueChanged)
             .bind(onNext: { [weak self] in
@@ -101,12 +119,13 @@ extension CategorySelectionViewController {
         /// ViewModel 입력값
         let input = CategorySelectionViewModel.Input(
             itemSelectionToggled: itemSelectionToggledRelay.asObservable(),
-            resetTapped: categorySelectionView.resetButton.rx.tap.asObservable(),
+            resetTapped: categorySelectionView.resetButton.rx.tap
+                .asObservable(),
             applyTapped: categorySelectionView.applyButton.rx.tap.asObservable()
         )
-
+        
         let output = viewModel.transform(input)
-
+        
         /// 아이템 목록 바인딩
         output.items
             .bind(onNext: { [weak self] items in
@@ -118,7 +137,7 @@ extension CategorySelectionViewController {
                 self.applySnapshot(with: items)
             })
             .disposed(by: disposeBag)
-
+        
         /// 적용 버튼 타이틀 바인딩
         output.applyButtonTitle
             .bind(onNext: { [weak self] title in
@@ -126,27 +145,101 @@ extension CategorySelectionViewController {
                 self.categorySelectionView.applyButton.updateTitle(title)
             })
             .disposed(by: disposeBag)
-
+        
         /// 적용 결과 바인딩
         output.appliedItemIDs
             .bind(onNext: { [weak self] selectedItemIDs in
                 guard let self else { return }
-                self.onApply?(selectedItemIDs)
-                self.dismiss(animated: true)
+                animateOut {
+                    self.onApply?(selectedItemIDs)
+                    self.dismiss(animated: false)
+                }
             })
             .disposed(by: disposeBag)
     }
 }
 
 //MARK: - Action
-private extension CategorySelectionViewController {
-    /// 배경 선택 이벤트
+extension CategorySelectionViewController {
+    fileprivate func animateIn() {
+        view.layoutIfNeeded()
+        let contentView = categorySelectionView.contentView
+        contentView.transform = CGAffineTransform(
+            translationX: 0,
+            y: contentView.bounds.height + 300
+        )
+
+        UIView.animate(withDuration: 0.35, delay: 0, options: .curveEaseOut) {
+            self.categorySelectionView.dimmingView.alpha = 1
+            contentView.transform = .identity
+        }
+    }
+
+    fileprivate func animateOut(completion: @escaping () -> Void) {
+        let contentView = categorySelectionView.contentView
+
+        UIView.animate(
+            withDuration: 0.3,
+            delay: 0,
+            options: .curveEaseIn,
+            animations: {
+                self.categorySelectionView.dimmingView.alpha = 0
+                contentView.transform = CGAffineTransform(
+                    translationX: 0,
+                    y: contentView.bounds.height + 300
+                )
+            },
+            completion: { _ in
+                completion()
+            }
+        )
+    }
+
+    fileprivate func addPanGesture() {
+        let pan = UIPanGestureRecognizer(
+            target: self,
+            action: #selector(handlePan(_:))
+        )
+        pan.cancelsTouchesInView = false
+        categorySelectionView.contentView.addGestureRecognizer(pan)
+    }
+
     @objc
-    func didTapBackground(_ gesture: UITapGestureRecognizer) {
-        let location = gesture.location(in: view)
-        
-        if !categorySelectionView.frame.contains(location) {
-            dismiss(animated: true)
+    fileprivate func handlePan(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(
+            in: categorySelectionView.contentView
+        )
+        let velocity = gesture.velocity(in: categorySelectionView.contentView)
+        let contentView = categorySelectionView.contentView
+        let contentHeight = contentView.bounds.height
+
+        switch gesture.state {
+        case .changed:
+            let offsetY = max(0, translation.y)
+            contentView.transform = CGAffineTransform(
+                translationX: 0,
+                y: offsetY
+            )
+
+            let ratio = max(0, 1 - (offsetY / contentHeight))
+            categorySelectionView.dimmingView.alpha = ratio
+
+        case .ended, .cancelled:
+            if translation.y > contentHeight * 0.35 || velocity.y > 800 {
+                animateOut { self.dismiss(animated: false) }
+            } else {
+                UIView.animate(
+                    withDuration: 0.3,
+                    delay: 0,
+                    usingSpringWithDamping: 0.8,
+                    initialSpringVelocity: 0.5
+                ) {
+                    contentView.transform = .identity
+                    self.categorySelectionView.dimmingView.alpha = 1
+                }
+            }
+        default:
+            break
         }
     }
 }
@@ -154,17 +247,25 @@ private extension CategorySelectionViewController {
 //MARK: - DataSource
 extension CategorySelectionViewController {
     /// 데이터소스 설정
-    private func configureDataSource() -> UICollectionViewDiffableDataSource<Section, CategorySelectionItem> {
-        let cellCategory = UICollectionView.CellRegistration<CategorySelectionItemCell, CategorySelectionItem> {
-            cell, indexPath, item in
+    private func configureDataSource() -> UICollectionViewDiffableDataSource<
+        Section, CategorySelectionItem
+    > {
+        let cellCategory = UICollectionView.CellRegistration<
+            CategorySelectionItemCell, CategorySelectionItem
+        > {
+            cell,
+            indexPath,
+            item in
             cell.updateUI(
                 title: item.title,
                 image: item.image,
                 isSelect: item.isSelect
             )
         }
-        
-        return UICollectionViewDiffableDataSource<Section, CategorySelectionItem>(
+
+        return UICollectionViewDiffableDataSource<
+            Section, CategorySelectionItem
+        >(
             collectionView: categorySelectionView.collectionView
         ) { collectionView, indexPath, item in
             collectionView.dequeueConfiguredReusableCell(
@@ -174,38 +275,18 @@ extension CategorySelectionViewController {
             )
         }
     }
-    
+
     /// 스냅샷 적용
     func applySnapshot(with datas: [CategorySelectionItem]) {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, CategorySelectionItem>()
+        var snapshot = NSDiffableDataSourceSnapshot<
+            Section, CategorySelectionItem
+        >()
         snapshot.appendSections([.main])
         snapshot.appendItems(datas, toSection: .main)
         dataSource.apply(snapshot, animatingDifferences: false)
     }
 }
 
-//MARK: - Configure UI
-extension CategorySelectionViewController {
-    /// UI 설정
-    private func configureUI() {
-        view.backgroundColor = .clear
-        view.overrideUserInterfaceStyle = .light
-
-        let tapGesture = UITapGestureRecognizer(
-            target: self,
-            action: #selector(didTapBackground)
-        )
-        tapGesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(tapGesture)
-
-        view.addSubview(categorySelectionView)
-
-        categorySelectionView.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalToSuperview()
-            $0.height.equalTo(356)
-        }
-    }
-}
 
 #Preview {
     CategorySelectionViewController(

--- a/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
@@ -8,10 +8,14 @@
 import SnapKit
 import Then
 import UIKit
+import RxCocoa
+import RxSwift
 
 final class ProductCollectionView: UIView {
 
     //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private let itemSelectedRelay = PublishRelay<ProductCellItem>()
     private lazy var dataSource = configureDataSource()
 
     //MARK: - Components
@@ -55,6 +59,7 @@ final class ProductCollectionView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
+        bind()
     }
 
     required init?(coder: NSCoder) {
@@ -86,6 +91,11 @@ extension ProductCollectionView {
         config.attributedTitle = attributedTitle
 
         sortedButton.configuration = config
+    }
+    
+    /// 상품 셀 선택 이벤트
+    var itemSelected: Observable<ProductCellItem> {
+        itemSelectedRelay.asObservable()
     }
 
     func applySnapshot(with productDatas: [ProductCellItem]) {
@@ -210,5 +220,23 @@ extension ProductCollectionView {
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(16)
         }
+    }
+}
+
+//MARK: - Binding
+private extension ProductCollectionView {
+    func bind() {
+        collectionView.rx.itemSelected
+            .do(onNext: { [weak self] indexPath in
+                self?.collectionView.deselectItem(
+                    at: indexPath,
+                    animated: false
+                )
+            })
+            .compactMap { [weak self] indexPath in
+                self?.dataSource.itemIdentifier(for: indexPath)
+            }
+            .bind(to: itemSelectedRelay)
+            .disposed(by: disposeBag)
     }
 }

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
@@ -11,8 +11,6 @@ import SnapKit
 import RxSwift
 
 
-
-
 final class ProductDetailView: UIView {
     
     
@@ -21,31 +19,51 @@ final class ProductDetailView: UIView {
         $0.contentMode = .scaleAspectFill
         $0.clipsToBounds = true
         $0.layer.cornerRadius = 8
+    }.then {
+        $0.image = UIImage(named: "iconSelectIcon")
     }
-    let productNameLabel = StyledLabel(config: .titleBold24)
+    
+    
+    let productNameLabel = StyledLabel(config: .titleBold24).then {
+        $0.text = "상품명"
+    }
     
     let countLabel = StyledLabel(
-        config: LabelConfiguration.body12.updatingColor(color: .accent)
-    )
+        config: LabelConfiguration.titleBold28.updatingColor(color: .accent)
+    ).then {
+        $0.text = "00"
+    }
     
     let countTitleLabel = StyledLabel(
         config: LabelConfiguration.titleSemi20.updatingColor(color: .gray500))
-    
+        .then {
+            $0.text = "개"
+        }
+
     let scrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
         $0.alwaysBounceVertical = true
+        $0.backgroundColor = .white
     }
     
-    let scrollContentView = UIView()
+    let scrollContentView = UIView().then {
+        $0.backgroundColor = .white
+    }
 
     let mainStackView = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 16
-        $0.distribution = .equalSpacing
-        $0.alignment = .leading
+        $0.distribution = .fill
+        $0.alignment = .fill
         $0.backgroundColor = .white
         $0.layer.cornerRadius = 8
         $0.isLayoutMarginsRelativeArrangement = true
+        $0.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 16,
+            leading: 16,
+            bottom: 16,
+            trailing: 16
+        )
         $0.layer.borderColor = UIColor.gray100.cgColor
         $0.layer.borderWidth = 1
     }
@@ -53,11 +71,17 @@ final class ProductDetailView: UIView {
     let subStackView = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 16
-        $0.distribution = .equalSpacing
-        $0.alignment = .leading
+        $0.distribution = .fill
+        $0.alignment = .fill
         $0.backgroundColor = .white
         $0.layer.cornerRadius = 8
         $0.isLayoutMarginsRelativeArrangement = true
+        $0.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 16,
+            leading: 16,
+            bottom: 16,
+            trailing: 16
+        )
         $0.layer.borderColor = UIColor.gray100.cgColor
         $0.layer.borderWidth = 1
     }
@@ -121,18 +145,18 @@ extension ProductDetailView {
             mainStackView.addArrangedSubview(view)
         }
 
-        guard displayModel.subInfos.count == 0 else {
+        if displayModel.subInfos.isEmpty {
             subStackView.isHidden = true
-            return
-        }
-        
-        displayModel.subInfos.forEach { item in
-            let view = createInfoView(
-                image: item.icon ?? UIImage(),
-                title: item.title,
-                detail: item.detail
-            )
-            subStackView.addArrangedSubview(view)
+        } else {
+            subStackView.isHidden = false
+            displayModel.subInfos.forEach { item in
+                let view = createInfoView(
+                    image: item.icon ?? UIImage(),
+                    title: item.title,
+                    detail: item.detail
+                )
+                subStackView.addArrangedSubview(view)
+            }
         }
     }
     
@@ -150,9 +174,14 @@ extension ProductDetailView {
 
 extension ProductDetailView {
     private func configureUI() {
-        
-        let topView = UIView()
-        let bottomView = UIView()
+        backgroundColor = .white
+
+        let topView = UIView().then {
+            $0.backgroundColor = .white
+        }
+        let bottomView = UIView().then {
+            $0.backgroundColor = .white
+        }
                 
         topView.addSubview(productImageView)
         topView.addSubview(productNameLabel)
@@ -161,33 +190,38 @@ extension ProductDetailView {
         bottomView.addSubview(deleteButton)
         bottomView.addSubview(modifyButton)
         
+        addSubview(scrollView)
+        addSubview(bottomView)
+        
+        scrollView.addSubview(scrollContentView)
         scrollContentView.addSubview(topView)
         scrollContentView.addSubview(mainStackView)
         scrollContentView.addSubview(subStackView)
         
-        addSubview(topView)
-        addSubview(scrollContentView)
-        addSubview(bottomView)
-        
-        topView.snp.makeConstraints {
+        scrollView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(66)
-        }
-        
-        scrollView.snp.makeConstraints {
-            $0.top.leading.trailing.equalTo(safeAreaLayoutGuide)
             $0.bottom.equalTo(bottomView.snp.top).offset(-16)
         }
+        
         scrollContentView.snp.makeConstraints {
             $0.edges.equalTo(scrollView.contentLayoutGuide)
             $0.width.equalTo(scrollView.frameLayoutGuide)
         }
         
+        topView.snp.makeConstraints {
+            $0.top.equalTo(scrollContentView)
+            $0.leading.trailing.equalTo(scrollContentView)
+            $0.height.equalTo(66)
+        }
+        
+        
+        
         bottomView.snp.makeConstraints {
-            $0.trailing.equalToSuperview()
             $0.leading.equalToSuperview()
             $0.trailing.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(16)
+            $0.height.equalTo(44)
         }
         
         productImageView.snp.makeConstraints {
@@ -199,30 +233,30 @@ extension ProductDetailView {
         productNameLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalTo(productImageView.snp.trailing).offset(8)
-            $0.trailing.equalTo(countTitleLabel.snp.leading)
         }
         
         countTitleLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().inset(16)
         }
         
         countLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.trailing.equalTo(countTitleLabel.snp.leading)
+
         }
         
         mainStackView.snp.makeConstraints {
             $0.top.equalTo(topView.snp.bottom)
-            $0.leading.equalToSuperview().offset(16)
-            $0.trailing.equalToSuperview().inset(16)
+            $0.leading.equalTo(scrollContentView).offset(16)
+            $0.trailing.equalTo(scrollContentView).inset(16)
         }
         
         subStackView.snp.makeConstraints {
             $0.top.equalTo(mainStackView.snp.bottom).offset(16)
-            $0.leading.equalToSuperview().offset(16)
-            $0.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview()
+            $0.leading.equalTo(scrollContentView).offset(16)
+            $0.trailing.equalTo(scrollContentView).inset(16)
+            $0.bottom.equalTo(scrollContentView)
         }
     
         deleteButton.snp.makeConstraints {
@@ -239,4 +273,55 @@ extension ProductDetailView {
             $0.height.equalTo(44)
         }
     }
+}
+
+#Preview {
+    let viewController = UIViewController()
+    let view = ProductDetailView()
+    
+    viewController.view.backgroundColor = .white
+    viewController.view.addSubview(view)
+    
+    view.snp.makeConstraints {
+        $0.edges.equalTo(viewController.view.safeAreaLayoutGuide)
+    }
+    
+    view.updateUI(
+        displayModel: ProductDetailDisplayModel(
+            headerImage: UIImage(named: "iconSelectIcon"),
+            productName: "식빵",
+            productCount: "1",
+            mainInfos: [
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "square.grid.2x2"),
+                    title: "대분류",
+                    detail: "식재료"
+                ),
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "folder"),
+                    title: "중분류",
+                    detail: "빵"
+                ),
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "calendar"),
+                    title: "등록일",
+                    detail: "2026.04.17"
+                )
+            ],
+            subInfos: [
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "tag"),
+                    title: "소분류",
+                    detail: "베이커리"
+                ),
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "clock"),
+                    title: "소비기한",
+                    detail: "2026.04.25"
+                )
+            ]
+        )
+    )
+    
+    return viewController
 }

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
@@ -1,0 +1,257 @@
+//
+//  ProductDetailView.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 4/16/26.
+//
+
+import UIKit
+import Then
+import SnapKit
+import RxSwift
+
+/// 상세화면 전용 구조체
+// TODO: 추후 ViewModel로 이관예정
+struct ProductDetailDisplayModel {
+    let headerImage: UIImage?
+    let productName: String
+    let productCount: String
+
+    let mainInfos: [ProductDetailInfoItem]
+    let subInfos: [ProductDetailInfoItem]
+}
+
+struct ProductDetailInfoItem {
+    let icon: UIImage?
+    let title: String
+    let detail: String
+}
+
+
+final class ProductDetailView: UIView {
+    
+    
+    //MARK: - Components
+    let productImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = 8
+    }
+    let productNameLabel = StyledLabel(config: .titleBold24)
+    
+    let countLabel = StyledLabel(
+        config: LabelConfiguration.body12.updatingColor(color: .accent)
+    )
+    
+    let countTitleLabel = StyledLabel(
+        config: LabelConfiguration.titleSemi20.updatingColor(color: .gray500))
+    
+    let scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = false
+        $0.alwaysBounceVertical = true
+    }
+    
+    let scrollContentView = UIView()
+
+    let mainStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 16
+        $0.distribution = .equalSpacing
+        $0.alignment = .leading
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 8
+        $0.isLayoutMarginsRelativeArrangement = true
+        $0.layer.borderColor = UIColor.gray100.cgColor
+        $0.layer.borderWidth = 1
+    }
+    
+    let subStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 16
+        $0.distribution = .equalSpacing
+        $0.alignment = .leading
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 8
+        $0.isLayoutMarginsRelativeArrangement = true
+        $0.layer.borderColor = UIColor.gray100.cgColor
+        $0.layer.borderWidth = 1
+    }
+    
+    let deleteButton = StyledButton(
+        title: "삭제",
+        titleConfiguration: .redTitle,
+        appearanceConfiguration: .redAppearance
+    ).then {
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = 8
+    }
+    
+    let modifyButton = StyledButton(
+        title: "수정하기",
+        titleConfiguration: .defaultTitle,
+        appearanceConfiguration: .defaultAppearance
+    ).then {
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = 8
+    }
+    
+    
+    
+    //MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
+extension ProductDetailView {
+    
+    func updateUI(displayModel: ProductDetailDisplayModel) {
+        productImageView.image = displayModel.headerImage
+        productNameLabel.text = displayModel.productName
+        countLabel.text = displayModel.productCount
+        countTitleLabel.text = "개"
+
+        mainStackView.arrangedSubviews.forEach {
+            mainStackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+
+        subStackView.arrangedSubviews.forEach {
+            subStackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+
+        displayModel.mainInfos.forEach { item in
+            let view = createInfoView(
+                image: item.icon ?? UIImage(),
+                title: item.title,
+                detail: item.detail
+            )
+            mainStackView.addArrangedSubview(view)
+        }
+
+        guard displayModel.subInfos.count == 0 else {
+            subStackView.isHidden = true
+            return
+        }
+        
+        displayModel.subInfos.forEach { item in
+            let view = createInfoView(
+                image: item.icon ?? UIImage(),
+                title: item.title,
+                detail: item.detail
+            )
+            subStackView.addArrangedSubview(view)
+        }
+    }
+    
+    private func createInfoView(
+        image: UIImage,
+        title: String,
+        detail: String )
+    -> ProductInfoView {
+        let infoView = ProductInfoView()
+        infoView.updateUI(image: image, title: title, detail: detail)
+        return infoView
+    }
+    
+}
+
+extension ProductDetailView {
+    private func configureUI() {
+        
+        let topView = UIView()
+        let bottomView = UIView()
+                
+        topView.addSubview(productImageView)
+        topView.addSubview(productNameLabel)
+        topView.addSubview(countLabel)
+        topView.addSubview(countTitleLabel)
+        bottomView.addSubview(deleteButton)
+        bottomView.addSubview(modifyButton)
+        
+        scrollContentView.addSubview(topView)
+        scrollContentView.addSubview(mainStackView)
+        scrollContentView.addSubview(subStackView)
+        
+        addSubview(topView)
+        addSubview(scrollContentView)
+        addSubview(bottomView)
+        
+        topView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(66)
+        }
+        
+        scrollView.snp.makeConstraints {
+            $0.top.leading.trailing.equalTo(safeAreaLayoutGuide)
+            $0.bottom.equalTo(bottomView.snp.top).offset(-16)
+        }
+        scrollContentView.snp.makeConstraints {
+            $0.edges.equalTo(scrollView.contentLayoutGuide)
+            $0.width.equalTo(scrollView.frameLayoutGuide)
+        }
+        
+        bottomView.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview()
+        }
+        
+        productImageView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(16)
+            $0.size.equalTo(36)
+        }
+        
+        productNameLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(productImageView.snp.trailing).offset(8)
+            $0.trailing.equalTo(countTitleLabel.snp.leading)
+        }
+        
+        countTitleLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(16)
+        }
+        
+        countLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalTo(countTitleLabel.snp.leading)
+        }
+        
+        mainStackView.snp.makeConstraints {
+            $0.top.equalTo(topView.snp.bottom)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().inset(16)
+        }
+        
+        subStackView.snp.makeConstraints {
+            $0.top.equalTo(mainStackView.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview()
+        }
+    
+        deleteButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(16)
+            $0.width.equalTo(89)
+            $0.height.equalTo(44)
+        }
+        
+        modifyButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(deleteButton.snp.trailing).offset(16)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(44)
+        }
+    }
+}

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
@@ -10,22 +10,7 @@ import Then
 import SnapKit
 import RxSwift
 
-/// 상세화면 전용 구조체
-// TODO: 추후 ViewModel로 이관예정
-struct ProductDetailDisplayModel {
-    let headerImage: UIImage?
-    let productName: String
-    let productCount: String
 
-    let mainInfos: [ProductDetailInfoItem]
-    let subInfos: [ProductDetailInfoItem]
-}
-
-struct ProductDetailInfoItem {
-    let icon: UIImage?
-    let title: String
-    let detail: String
-}
 
 
 final class ProductDetailView: UIView {

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
@@ -1,0 +1,74 @@
+//
+//  ProductDetailViewController.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 4/16/26.
+//
+
+import UIKit
+import Then
+import SnapKit
+import RxSwift
+import RxCocoa
+
+
+final class ProductDetailViewController: UIViewController {
+    
+
+    let viewModel: ProductDetailViewModel
+    
+    let disposeBag = DisposeBag()
+    
+    let productDetailView = ProductDetailView()
+
+    
+    //MARK: - Init
+    init(viewModel: ProductDetailViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        overrideUserInterfaceStyle = .light
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        bind()
+    }
+}
+
+extension ProductDetailViewController {
+    private func bind() {
+        let input = ProductDetailViewModel.Input(
+            viewDidLoad: Observable.just(())
+        )
+        
+        let output = viewModel.transform(input)
+        
+        output.viewUpdate
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] displayModel in
+                guard let self else { return }
+                self.title = displayModel.productName
+                self.productDetailView.updateUI(displayModel: displayModel)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+
+extension ProductDetailViewController {
+    
+    private func configureUI() {
+        view.backgroundColor = .white
+        view.addSubview(productDetailView)
+        
+        productDetailView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/JaengYeo/JaengYeo/View/Stock/ProductInfoView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductInfoView.swift
@@ -15,13 +15,19 @@ final class ProductInfoView: UIView {
     //MARK: - Components
     private let iconImageView = UIImageView().then {
         $0.backgroundColor = .clear
+        $0.contentMode = .scaleAspectFit
+        // Force consistent icon color (some assets are template images).
+        $0.tintColor = .gray500
     }
     
     private let titleLabel = StyledLabel(
         config: LabelConfiguration.body12.updatingColor(color: .gray300)
     )
     
-    private let detailLabel = StyledLabel(config: .titleSemi16)
+    private let detailLabel = StyledLabel(config: .titleSemi16).then {
+        $0.numberOfLines = 0
+        $0.lineBreakMode = .byWordWrapping
+    }
    
     private let modifyButton = StyledButton(
         title: "수정하기",
@@ -43,7 +49,7 @@ final class ProductInfoView: UIView {
 
 extension ProductInfoView {
     func updateUI(image: UIImage, title: String, detail: String) {
-        iconImageView.image = image
+        iconImageView.image = image.withRenderingMode(.alwaysTemplate)
         titleLabel.text = title
         detailLabel.text = detail
     }
@@ -52,9 +58,15 @@ extension ProductInfoView {
 extension ProductInfoView {
     private func configureUI() {
          
+        // Default row height is 37, but memo/caution can be multi-line.
+        snp.makeConstraints {
+            $0.height.greaterThanOrEqualTo(37)
+        }
+
         addSubview(iconImageView)
         addSubview(titleLabel)
         addSubview(detailLabel)
+        
         
         iconImageView.snp.makeConstraints {
             $0.centerY.equalToSuperview()
@@ -69,7 +81,7 @@ extension ProductInfoView {
         }
             
         detailLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel).offset(4)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
             $0.leading.equalTo(iconImageView.snp.trailing).offset(16)
             $0.trailing.bottom.equalToSuperview()
         }

--- a/JaengYeo/JaengYeo/View/Stock/ProductInfoView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductInfoView.swift
@@ -1,0 +1,77 @@
+//
+//  ProductInfoView.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 4/16/26.
+//
+
+import UIKit
+import Then
+import SnapKit
+import RxSwift
+
+final class ProductInfoView: UIView {
+    
+    //MARK: - Components
+    private let iconImageView = UIImageView().then {
+        $0.backgroundColor = .clear
+    }
+    
+    private let titleLabel = StyledLabel(
+        config: LabelConfiguration.body12.updatingColor(color: .gray300)
+    )
+    
+    private let detailLabel = StyledLabel(config: .titleSemi16)
+   
+    private let modifyButton = StyledButton(
+        title: "수정하기",
+        titleConfiguration: .defaultTitle,
+        appearanceConfiguration: .defaultAppearance
+    )
+    
+    //MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension ProductInfoView {
+    func updateUI(image: UIImage, title: String, detail: String) {
+        iconImageView.image = image
+        titleLabel.text = title
+        detailLabel.text = detail
+    }
+}
+
+extension ProductInfoView {
+    private func configureUI() {
+         
+        addSubview(iconImageView)
+        addSubview(titleLabel)
+        addSubview(detailLabel)
+        
+        iconImageView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview()
+            $0.size.equalTo(24)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalTo(iconImageView.snp.trailing).offset(16)
+            $0.trailing.equalToSuperview()
+        }
+            
+        detailLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel).offset(4)
+            $0.leading.equalTo(iconImageView.snp.trailing).offset(16)
+            $0.trailing.bottom.equalToSuperview()
+        }
+    }
+}

--- a/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
@@ -45,8 +45,8 @@ final class StockSearchViewController: UIViewController {
         
         let textField = $0.searchTextField
         textField.backgroundColor = .gray50
-        textField.font = LabelConfiguration.bodyMedium12.font
-        textField.layer.cornerRadius = 22
+        textField.font = LabelConfiguration.bodyMedium14.font
+        textField.layer.cornerRadius = 20
         textField.layer.masksToBounds = true
         textField.borderStyle = .none
     }
@@ -229,7 +229,7 @@ private extension StockSearchViewController {
             $0.centerY.equalTo(backButton.snp.centerY)
             $0.leading.equalTo(backButton.snp.trailing).offset(8)
             $0.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(44)
+            $0.height.equalTo(40)
         }
 
         collectionView.snp.makeConstraints {

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -189,7 +189,7 @@ private extension StockViewController {
     ) {
         let viewController = CategorySelectionViewController(items: items)
         viewController.onApply = onApply
-        present(viewController, animated: true)
+        present(viewController, animated: false)
     }
 }
 

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -15,6 +15,7 @@ import UIKit
 protocol StockViewControllerDelegate: AnyObject {
     func didTapCategoryEditButton()
     func didTapSearchButton()
+    func didSelectProduct(productID: UUID)
 }
 
 final class StockViewController: UIViewController {
@@ -80,6 +81,12 @@ private extension StockViewController {
         productCollectionView.configureSortMenu { sortOption in
             sortOptionSelectedRelay.accept(sortOption)
         }
+        
+        productCollectionView.itemSelected
+            .bind(onNext: { [weak self] item in
+                self?.delegate?.didSelectProduct(productID: item.product.id)
+            })
+            .disposed(by: disposeBag)
         
         /// ViewModel 입력값
         let input = StockViewModel.Input(

--- a/JaengYeo/JaengYeo/ViewModel/Stock/ProductDetailViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/ProductDetailViewModel.swift
@@ -47,7 +47,7 @@ final class ProductDetailViewModel: NSObject, ViewModelProtocol {
     private let productRelay = BehaviorRelay<Product?>(value: nil)
     private let midCategoryRelay = BehaviorRelay<MidCategory?>(value: nil)
     private let subCategoryRelay = BehaviorRelay<SubCategory?>(value: nil)
-    private let displayModelRelay = PublishRelay<ProductDetailDisplayModel>()
+    private let displayModelRelay = BehaviorRelay<ProductDetailDisplayModel?>(value: nil)
 
     
     struct Input {
@@ -69,7 +69,9 @@ final class ProductDetailViewModel: NSObject, ViewModelProtocol {
             .disposed(by: disposeBag)
         
         return Output(
-            viewUpdate: displayModelRelay.asObservable()
+            viewUpdate: displayModelRelay
+                .compactMap { $0 }
+                .asObservable()
         )
     }
     
@@ -81,18 +83,28 @@ final class ProductDetailViewModel: NSObject, ViewModelProtocol {
 }
 
 
-extension ProductDetailViewModel: NSFetchedResultsControllerDelegate  {
-    private func configureProductFetchResultController(id: UUID){
-        let request = ProductEntity.fetchRequest()
-        request.fetchLimit = 1
-        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+    extension ProductDetailViewModel: NSFetchedResultsControllerDelegate  {
+        private func configureProductFetchResultController(id: UUID){
+            let request = ProductEntity.fetchRequest()
+            request.sortDescriptors = [
+                NSSortDescriptor(
+                    key: ProductEntity.Keys.createdAt,
+                    ascending: false
+                )
+            ]
+            request.fetchLimit = 1
+            request.predicate = NSPredicate(
+                format: "%K == %@",
+                ProductEntity.Keys.id,
+                id as CVarArg
+            )
 
-        let controller = NSFetchedResultsController(
-            fetchRequest: request,
-            managedObjectContext: coreDataManager.context,
-            sectionNameKeyPath: nil,
-            cacheName: nil
-        )
+            let controller = NSFetchedResultsController(
+                fetchRequest: request,
+                managedObjectContext: coreDataManager.context,
+                sectionNameKeyPath: nil,
+                cacheName: nil
+            )
 
         controller.delegate = self
         productFetchResultController = controller
@@ -106,6 +118,7 @@ extension ProductDetailViewModel: NSFetchedResultsControllerDelegate  {
             productRelay.accept(nil)
             midCategoryRelay.accept(nil)
             subCategoryRelay.accept(nil)
+            displayModelRelay.accept(makeNotFoundDisplayModel())
         }
     }
     
@@ -114,6 +127,7 @@ extension ProductDetailViewModel: NSFetchedResultsControllerDelegate  {
             productRelay.accept(nil)
             midCategoryRelay.accept(nil)
             subCategoryRelay.accept(nil)
+            displayModelRelay.accept(makeNotFoundDisplayModel())
             return
         }
 
@@ -171,6 +185,16 @@ extension ProductDetailViewModel: NSFetchedResultsControllerDelegate  {
 }
 
 private extension ProductDetailViewModel {
+    func makeNotFoundDisplayModel() -> ProductDetailDisplayModel {
+        ProductDetailDisplayModel(
+            headerImage: UIImage(named: "iconSelectIcon"),
+            productName: "상품을 불러오지 못했어요",
+            productCount: "-",
+            mainInfos: [],
+            subInfos: []
+        )
+    }
+
     func makeDisplayModel(
         product: Product,
         midCategory: MidCategory?,
@@ -191,17 +215,17 @@ private extension ProductDetailViewModel {
 
         let mainInfos: [ProductDetailInfoItem] = [
             ProductDetailInfoItem(
-                icon: UIImage(systemName: "square.grid.2x2"),
+                icon: UIImage(named: ProductInfoIcon.mainCategoryIcon.rawValue),
                 title: "대분류",
                 detail: product.mainCategory
             ),
             ProductDetailInfoItem(
-                icon: UIImage(systemName: "folder"),
+                icon: UIImage(named: ProductInfoIcon.midCategoryIcon.rawValue),
                 title: "중분류",
                 detail: midCategory?.name ?? "-"
             ),
             ProductDetailInfoItem(
-                icon: UIImage(systemName: "calendar"),
+                icon: UIImage(named: ProductInfoIcon.purchaseDateIcon.rawValue),
                 title: "등록일",
                 detail: formatDate(product.createdAt)
             )
@@ -212,8 +236,8 @@ private extension ProductDetailViewModel {
         if let subCategory {
             subInfos.append(
                 ProductDetailInfoItem(
-                    icon: UIImage(systemName: "tag"),
-                    title: "소분류",
+                    icon: UIImage(named: ProductInfoIcon.subCategoryIcon.rawValue),
+                    title: "소분류 (종류)",
                     detail: subCategory.name
                 )
             )
@@ -222,28 +246,19 @@ private extension ProductDetailViewModel {
         if let expiryDate = product.expiryDate {
             subInfos.append(
                 ProductDetailInfoItem(
-                    icon: UIImage(systemName: "clock"),
+                    icon: UIImage(named: ProductInfoIcon.expiryDateIcon.rawValue),
                     title: "소비기한",
                     detail: formatDate(expiryDate)
                 )
             )
         }
 
-        if let memo = product.memo, !memo.isEmpty {
-            subInfos.append(
-                ProductDetailInfoItem(
-                    icon: UIImage(systemName: "note.text"),
-                    title: "메모",
-                    detail: memo
-                )
-            )
-        }
 
         if let caution = product.caution, !caution.isEmpty {
             subInfos.append(
                 ProductDetailInfoItem(
-                    icon: UIImage(systemName: "exclamationmark.triangle"),
-                    title: "주의사항",
+                    icon: UIImage(named: ProductInfoIcon.cautionIcon.rawValue),
+                    title: "유의사항/취급 주의사항",
                     detail: caution
                 )
             )
@@ -252,23 +267,34 @@ private extension ProductDetailViewModel {
         if let brand = product.brand, !brand.isEmpty {
             subInfos.append(
                 ProductDetailInfoItem(
-                    icon: UIImage(systemName: "shippingbox"),
+                    icon: UIImage(named: ProductInfoIcon.brandIcon.rawValue),
                     title: "브랜드",
                     detail: brand
                 )
             )
         }
 
-        if product.lowStockThreshold > 0 {
+        if product.isLowStockNotificationEnabled,
+           product.lowStockThreshold > 0 {
             subInfos.append(
                 ProductDetailInfoItem(
-                    icon: UIImage(systemName: "bell"),
-                    title: "재고 부족 기준",
+                    icon: UIImage(named: ProductInfoIcon.lowStockThresholdIcon.rawValue),
+                    title: "알림 재고 수량",
                     detail: "\(product.lowStockThreshold)"
                 )
             )
         }
 
+        if let memo = product.memo, !memo.isEmpty {
+            subInfos.append(
+                ProductDetailInfoItem(
+                    icon: UIImage(named: ProductInfoIcon.memoIcon.rawValue),
+                    title: "메모",
+                    detail: memo
+                )
+            )
+        }
+         
         return ProductDetailDisplayModel(
             headerImage: headerImage,
             productName: product.name,

--- a/JaengYeo/JaengYeo/ViewModel/Stock/ProductDetailViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/ProductDetailViewModel.swift
@@ -1,0 +1,286 @@
+//
+//  ProductDetailViewModel.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 4/16/26.
+//
+
+
+import Foundation
+import CoreData
+import UIKit
+import RxSwift
+import RxRelay
+
+/// 상세화면 전용 구조체
+// TODO: 추후 ViewModel로 이관예정
+struct ProductDetailDisplayModel {
+    let headerImage: UIImage?
+    let productName: String
+    let productCount: String
+
+    let mainInfos: [ProductDetailInfoItem]
+    let subInfos: [ProductDetailInfoItem]
+}
+
+struct ProductDetailInfoItem {
+    let icon: UIImage?
+    let title: String
+    let detail: String
+}
+
+final class ProductDetailViewModel: NSObject, ViewModelProtocol {
+   
+    //MARK: - Properties
+    /// 메모리 해제 가방
+    private let disposeBag = DisposeBag()
+    
+    /// 상품
+    private let productID: UUID
+    
+    /// CoreData 매니저
+    private let coreDataManager: CoreDataManagerProtocol
+
+    
+    private var productFetchResultController: NSFetchedResultsController<ProductEntity>?
+    
+    private let productRelay = BehaviorRelay<Product?>(value: nil)
+    private let midCategoryRelay = BehaviorRelay<MidCategory?>(value: nil)
+    private let subCategoryRelay = BehaviorRelay<SubCategory?>(value: nil)
+    private let displayModelRelay = PublishRelay<ProductDetailDisplayModel>()
+
+    
+    struct Input {
+        let viewDidLoad: Observable<Void>
+    }
+    
+    struct Output {
+        let viewUpdate: Observable<ProductDetailDisplayModel>
+    }
+    
+    func transform(_ input: Input) -> Output {
+        
+        input.viewDidLoad
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.configureProductFetchResultController(id: productID)
+                self.performFetch()
+            })
+            .disposed(by: disposeBag)
+        
+        return Output(
+            viewUpdate: displayModelRelay.asObservable()
+        )
+    }
+    
+    init(productID: UUID, coreDataManager: CoreDataManagerProtocol){
+        self.productID = productID
+        self.coreDataManager = coreDataManager
+        super.init()
+    }
+}
+
+
+extension ProductDetailViewModel: NSFetchedResultsControllerDelegate  {
+    private func configureProductFetchResultController(id: UUID){
+        let request = ProductEntity.fetchRequest()
+        request.fetchLimit = 1
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+
+        let controller = NSFetchedResultsController(
+            fetchRequest: request,
+            managedObjectContext: coreDataManager.context,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
+
+        controller.delegate = self
+        productFetchResultController = controller
+    }
+    
+    private func performFetch() {
+        do {
+            try productFetchResultController?.performFetch()
+            updateProductDetail()
+        } catch {
+            productRelay.accept(nil)
+            midCategoryRelay.accept(nil)
+            subCategoryRelay.accept(nil)
+        }
+    }
+    
+    private func updateProductDetail() {
+        guard let productEntity = productFetchResultController?.fetchedObjects?.first else {
+            productRelay.accept(nil)
+            midCategoryRelay.accept(nil)
+            subCategoryRelay.accept(nil)
+            return
+        }
+
+        let product = productEntity.toDomain
+        productRelay.accept(product)
+
+        let midCategory = product.midCategoryId.flatMap { fetchMidCategory(id: $0) }
+        let subCategory = product.subCategoryId.flatMap { fetchSubCategory(id: $0) }
+
+        midCategoryRelay.accept(midCategory)
+        subCategoryRelay.accept(subCategory)
+
+        let displayModel = makeDisplayModel(
+            product: product,
+            midCategory: midCategory,
+            subCategory: subCategory
+        )
+        displayModelRelay.accept(displayModel)
+    }
+    
+    func fetchMidCategory(id: UUID) -> MidCategory? {
+           let request: NSFetchRequest<MidCategoryEntity> = MidCategoryEntity.fetchRequest()
+           request.fetchLimit = 1
+           request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+
+           do {
+               guard let midEntity = try coreDataManager.context.fetch(request).first else { return nil }
+               return midEntity.toDomain
+               
+           } catch {
+               return nil
+           }
+       }
+
+       func fetchSubCategory(id: UUID) -> SubCategory? {
+           let request: NSFetchRequest<SubCategoryEntity> = SubCategoryEntity.fetchRequest()
+           request.fetchLimit = 1
+           request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+
+           do {
+               guard let subEntity = try coreDataManager.context.fetch(request).first else { return nil }
+               return subEntity.toDomain
+           } catch {
+               return nil
+           }
+       }
+    
+    func controllerDidChangeContent(
+        _ controller: NSFetchedResultsController<NSFetchRequestResult>
+    ) {
+        if controller == productFetchResultController {
+            updateProductDetail()
+        }
+    }
+}
+
+private extension ProductDetailViewModel {
+    func makeDisplayModel(
+        product: Product,
+        midCategory: MidCategory?,
+        subCategory: SubCategory?
+    ) -> ProductDetailDisplayModel {
+        let headerImage: UIImage? = {
+            if let fileName = product.imageUrl,
+               let image = ImageUtils.loadImage(fileName: fileName) {
+                return image
+            }
+
+            if let iconName = subCategory?.iconName {
+                return UIImage(named: iconName)
+            }
+
+            return UIImage(named: "iconSelectIcon")
+        }()
+
+        let mainInfos: [ProductDetailInfoItem] = [
+            ProductDetailInfoItem(
+                icon: UIImage(systemName: "square.grid.2x2"),
+                title: "대분류",
+                detail: product.mainCategory
+            ),
+            ProductDetailInfoItem(
+                icon: UIImage(systemName: "folder"),
+                title: "중분류",
+                detail: midCategory?.name ?? "-"
+            ),
+            ProductDetailInfoItem(
+                icon: UIImage(systemName: "calendar"),
+                title: "등록일",
+                detail: formatDate(product.createdAt)
+            )
+        ]
+
+        var subInfos: [ProductDetailInfoItem] = []
+
+        if let subCategory {
+            subInfos.append(
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "tag"),
+                    title: "소분류",
+                    detail: subCategory.name
+                )
+            )
+        }
+
+        if let expiryDate = product.expiryDate {
+            subInfos.append(
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "clock"),
+                    title: "소비기한",
+                    detail: formatDate(expiryDate)
+                )
+            )
+        }
+
+        if let memo = product.memo, !memo.isEmpty {
+            subInfos.append(
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "note.text"),
+                    title: "메모",
+                    detail: memo
+                )
+            )
+        }
+
+        if let caution = product.caution, !caution.isEmpty {
+            subInfos.append(
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "exclamationmark.triangle"),
+                    title: "주의사항",
+                    detail: caution
+                )
+            )
+        }
+
+        if let brand = product.brand, !brand.isEmpty {
+            subInfos.append(
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "shippingbox"),
+                    title: "브랜드",
+                    detail: brand
+                )
+            )
+        }
+
+        if product.lowStockThreshold > 0 {
+            subInfos.append(
+                ProductDetailInfoItem(
+                    icon: UIImage(systemName: "bell"),
+                    title: "재고 부족 기준",
+                    detail: "\(product.lowStockThreshold)"
+                )
+            )
+        }
+
+        return ProductDetailDisplayModel(
+            headerImage: headerImage,
+            productName: product.name,
+            productCount: "\(product.quantity)",
+            mainInfos: mainInfos,
+            subInfos: subInfos
+        )
+    }
+
+    func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        return formatter.string(from: date)
+    }
+}


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #21

## 🛠 작업 내용 (What I did)
- 재고 상품 상세 화면을 신규로 구성하고, 목록에서 셀 선택 시 상세 화면으로 이동하도록 연결
- CoreData 기반으로 상품/분류 정보를 조회해 상세 화면에 표시

## 💻 구현 상세 (Implementation Details)
- ProductDetailViewModel: productID로 ProductEntity를 조회하고, 중/소분류를 추가 조회해 ProductDetailDisplayModel로 변환 후 방출
- ProductDetailViewController: viewUpdate 바인딩으로 타이틀/뷰 업데이트 처리
- ProductDetailView / ProductInfoView: 헤더(이미지/이름/수량), 정보 스택, 하단 버튼 레이아웃 구성 및 정보 아이템 렌더링
- StockCoordinator / StockViewController / ProductCollectionView: 셀 탭 이벤트를 상세 화면 push로 연결


## 📸 스크린샷 (Screenshots)
<img width="400" height="1000" alt="simulator_screenshot_2A87A7DF-B535-4309-B117-9F47211C775D" src="https://github.com/user-attachments/assets/58617146-8080-44ff-949f-08f810bd4244" />

## 작업 미비사항
- 하단 제거 및 수정하기 버튼 기능 구현 X
- 동일 이름 시, 모달 뷰 제작 X
