### PR TITLE
[FEAT] 재고화면 - 중복이름 처리 #89

### DIFF
--- a/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
@@ -5,9 +5,9 @@
 //  Created by Hanjuheon on 4/9/26.
 //
 
-import SnapKit
 import Then
 import UIKit
+import SnapKit
 import RxCocoa
 import RxSwift
 
@@ -67,8 +67,9 @@ final class ProductCollectionView: UIView {
     }
 }
 
-//MARK: - Configure CollectionView
+//MARK: - Public
 extension ProductCollectionView {
+    /// 정렬 메뉴 설정
     func configureSortMenu(
         onSelect: @escaping (ProductSortOption) -> Void
     ) {
@@ -82,6 +83,7 @@ extension ProductCollectionView {
         )
     }
 
+    /// 정렬 타이틀 변경
     func updateSortTitle(_ title: String) {
         var config = sortedButton.configuration ?? .plain()
 
@@ -98,6 +100,7 @@ extension ProductCollectionView {
         itemSelectedRelay.asObservable()
     }
 
+    /// 스냅샷 적용
     func applySnapshot(with productDatas: [ProductCellItem]) {
         let totalCount = productDatas.reduce(0) {
             $0 + $1.groupedCount
@@ -110,25 +113,24 @@ extension ProductCollectionView {
         snapshot.appendItems(productDatas, toSection: .defaultType)
         dataSource.apply(snapshot, animatingDifferences: true)
     }
+}
 
+//MARK: - DataSource
+private extension ProductCollectionView {
+    /// 데이터소스 설정
     func configureDataSource() -> UICollectionViewDiffableDataSource<
         ProductCellType, ProductCellItem
     > {
         let cellRegistration = UICollectionView.CellRegistration<
             ProductCell, ProductCellItem
-        > {
+        > { [weak self]
             cell,
             indexPath,
             item in
 
             var freshness: Int? = nil
             if let expiryDate = item.product.expiryDate {
-                freshness =
-                    Calendar.current.dateComponents(
-                        [.day],
-                        from: Date(),
-                        to: expiryDate
-                    ).day
+                freshness = self?.makeFreshness(expiryDate)
             }
 
             let descriptions = [
@@ -159,7 +161,22 @@ extension ProductCollectionView {
             )
         }
     }
+    
+    /// 소비기한 D-day 생성
+    func makeFreshness(_ expiryDate: Date) -> Int? {
+        let day = Calendar.current.dateComponents(
+            [.day],
+            from: Date(),
+            to: expiryDate
+        ).day
+        
+        return day.map { $0 + 1 }
+    }
+}
 
+//MARK: - Compositional Layout
+private extension ProductCollectionView {
+    /// 컬렉션 뷰 레이아웃 생성
     func createLayout() -> UICollectionViewLayout {
         let item = NSCollectionLayoutItem(
             layoutSize: .init(
@@ -189,8 +206,9 @@ extension ProductCollectionView {
     }
 }
 
-// MARK: - Configure UI
-extension ProductCollectionView {
+//MARK: - Configure UI
+private extension ProductCollectionView {
+    /// UI 설정
     func configureUI() {
         backgroundColor = .gray50
 

--- a/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
@@ -99,7 +99,10 @@ extension ProductCollectionView {
     }
 
     func applySnapshot(with productDatas: [ProductCellItem]) {
-        totalCountLabel.text = "총 \(productDatas.count)개"
+        let totalCount = productDatas.reduce(0) {
+            $0 + $1.groupedCount
+        }
+        totalCountLabel.text = "총 \(totalCount)개"
         var snapshot = NSDiffableDataSourceSnapshot<
             ProductCellType, ProductCellItem
         >()
@@ -135,11 +138,11 @@ extension ProductCollectionView {
 
             cell.updateUI(
                 type: .defaultType,
-                title: item.product.name,
+                title: item.displayTitle,
                 freshness: freshness,
                 descriptions: descriptions,
                 subdescriptions: nil,
-                count: item.product.quantity,
+                count: item.totalQuantity,
                 image: nil
             )
         }

--- a/JaengYeo/JaengYeo/View/Stock/ProductGroupListView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductGroupListView.swift
@@ -1,0 +1,276 @@
+//
+//  ProductGroupListView.swift
+//  JaengYeo
+//
+//  Created by Codex on 4/19/26.
+//
+
+import Then
+import UIKit
+import SnapKit
+import RxCocoa
+import RxSwift
+
+final class ProductGroupListView: UIView {
+
+    //MARK: - Enum
+    private enum Section {
+        case main
+    }
+
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private let itemSelectedRelay = PublishRelay<ProductCellItem>()
+    private lazy var dataSource = configureDataSource()
+
+    //MARK: - Components
+    /// 바텀 시트 시 뒷 배경
+    let dimmingView = UIView().then {
+        $0.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        $0.alpha = 0
+    }
+
+    /// 바텀 시트 컨텐츠 뷰
+    let contentView = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 20
+        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        $0.clipsToBounds = true
+    }
+
+    /// 상단 핸들 뷰
+    private let handleView = UIView().then {
+        $0.backgroundColor = .gray300
+        $0.layer.cornerRadius = 2.5
+    }
+
+    /// 모달 타이틀
+    let titleLabel = StyledLabel(config: .bodyMedium14).then {
+        $0.textAlignment = .left
+        $0.updateColor(.gray500)
+    }
+
+    /// 그룹 상품 컬렉션 뷰
+    private lazy var collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: createLayout()
+    ).then {
+        $0.backgroundColor = .white
+        $0.showsVerticalScrollIndicator = false
+    }
+
+    //MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        bind()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+//MARK: - Public
+extension ProductGroupListView {
+    /// 상품 셀 선택 이벤트
+    var itemSelected: Observable<ProductCellItem> {
+        itemSelectedRelay.asObservable()
+    }
+
+    /// 컬렉션 뷰 접근
+    var productCollectionView: UICollectionView {
+        collectionView
+    }
+
+    /// 스냅샷 적용
+    func applySnapshot(with items: [ProductCellItem]) {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, ProductCellItem>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(items, toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+}
+
+//MARK: - DataSource
+private extension ProductGroupListView {
+    /// 데이터소스 설정
+    private func configureDataSource() -> UICollectionViewDiffableDataSource<
+        Section,
+        ProductCellItem
+    > {
+        let cellRegistration = UICollectionView.CellRegistration<
+            ProductCell,
+            ProductCellItem
+        > { [weak self]
+            cell,
+            indexPath,
+            item in
+            guard let self else { return }
+
+            var freshness: Int? = nil
+            if let expiryDate = item.product.expiryDate {
+                freshness = self.makeFreshness(expiryDate)
+            }
+
+            let descriptions = [
+                item.midCategory,
+                item.subCategory,
+            ].compactMap { $0 }
+
+            cell.updateUI(
+                type: .homeType,
+                title: item.displayTitle,
+                freshness: freshness,
+                descriptions: descriptions,
+                subdescriptions: nil,
+                count: item.totalQuantity,
+                image: nil
+            )
+        }
+
+        return UICollectionViewDiffableDataSource<Section, ProductCellItem>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, item in
+            collectionView.dequeueConfiguredReusableCell(
+                using: cellRegistration,
+                for: indexPath,
+                item: item
+            )
+        }
+    }
+    
+    /// 소비기한 D-day 생성
+    func makeFreshness(_ expiryDate: Date) -> Int? {
+        let day = Calendar.current.dateComponents(
+            [.day],
+            from: Date(),
+            to: expiryDate
+        ).day
+        
+        return day.map { $0 + 1 }
+    }
+}
+
+//MARK: - Compositional Layout
+private extension ProductGroupListView {
+    /// 컬렉션 뷰 레이아웃 생성
+    func createLayout() -> UICollectionViewLayout {
+        let item = NSCollectionLayoutItem(
+            layoutSize: .init(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(88)
+            )
+        )
+
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: .init(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(88)
+            ),
+            subitems: [item]
+        )
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 8
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 16,
+            bottom: 16,
+            trailing: 16
+        )
+
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+}
+
+//MARK: - Configure UI
+private extension ProductGroupListView {
+    /// UI 설정
+    func configureUI() {
+        overrideUserInterfaceStyle = .light
+        backgroundColor = .clear
+
+        addSubview(dimmingView)
+        addSubview(contentView)
+
+        contentView.addSubview(handleView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(collectionView)
+
+        dimmingView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        contentView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.greaterThanOrEqualToSuperview()
+            $0.height.equalTo(280)
+        }
+
+        handleView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(8)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(40)
+            $0.height.equalTo(5)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(handleView.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(20)
+        }
+
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(8)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+}
+
+//MARK: - Binding
+private extension ProductGroupListView {
+    func bind() {
+        collectionView.rx.itemSelected
+            .do(onNext: { [weak self] indexPath in
+                self?.collectionView.deselectItem(
+                    at: indexPath,
+                    animated: false
+                )
+            })
+            .compactMap { [weak self] indexPath in
+                self?.dataSource.itemIdentifier(for: indexPath)
+            }
+            .bind(to: itemSelectedRelay)
+            .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - Date Format
+private extension Date {
+    /// 그룹 모달 날짜 표기
+    var formattedGroupDate: String {
+        ProductGroupListView.groupDateFormatter.string(from: self)
+    }
+}
+
+private extension ProductGroupListView {
+    /// 그룹 모달 날짜 포매터
+    static let groupDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+}
+
+#Preview {
+    let viewController = UIViewController()
+    let groupListView = ProductGroupListView()
+
+    viewController.view.addSubview(groupListView)
+    groupListView.snp.makeConstraints {
+        $0.edges.equalToSuperview()
+    }
+
+    return viewController
+}

--- a/JaengYeo/JaengYeo/View/Stock/ProductGroupListViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductGroupListViewController.swift
@@ -1,0 +1,205 @@
+//
+//  ProductGroupListViewController.swift
+//  JaengYeo
+//
+//  Created by Codex on 4/19/26.
+//
+
+import RxCocoa
+import RxSwift
+import UIKit
+
+final class ProductGroupListViewController: BaseViewController {
+
+    //MARK: - ViewModel
+    private let viewModel: ProductGroupListViewModel
+
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    var onSelect: ((UUID) -> Void)?
+
+    //MARK: - Components
+    private let mainView = ProductGroupListView()
+
+    //MARK: - Init
+    init(viewModel: ProductGroupListViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        overrideUserInterfaceStyle = .light
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = mainView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bind()
+        addPanGesture()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        animateIn()
+    }
+}
+
+//MARK: - Binding
+private extension ProductGroupListViewController {
+    func bind() {
+        let dimmingTap = UITapGestureRecognizer()
+        mainView.dimmingView.addGestureRecognizer(dimmingTap)
+
+        dimmingTap.rx.event
+            .bind(onNext: { [weak self] _ in
+                self?.close()
+            })
+            .disposed(by: disposeBag)
+
+        let input = ProductGroupListViewModel.Input(
+            viewDidLoad: Observable.just(()),
+            itemSelected: mainView.itemSelected
+        )
+
+        let output = viewModel.transform(input)
+
+        output.totalCountText
+            .bind(onNext: { [weak self] text in
+                self?.mainView.titleLabel.text = text
+            })
+            .disposed(by: disposeBag)
+
+        output.items
+            .bind(onNext: { [weak self] items in
+                self?.mainView.applySnapshot(with: items)
+            })
+            .disposed(by: disposeBag)
+
+        output.selectedProductID
+            .bind(onNext: { [weak self] productID in
+                self?.selectProduct(productID)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - Action
+private extension ProductGroupListViewController {
+    /// 상품 선택
+    func selectProduct(_ productID: UUID) {
+        animateOut { [weak self] in
+            self?.dismiss(animated: false) {
+                self?.onSelect?(productID)
+            }
+        }
+    }
+
+    /// 화면 닫기
+    func close() {
+        animateOut { [weak self] in
+            self?.dismiss(animated: false)
+        }
+    }
+}
+
+//MARK: - Animation
+private extension ProductGroupListViewController {
+    /// 바텀 시트 생성
+    func animateIn() {
+        view.layoutIfNeeded()
+        let contentView = mainView.contentView
+        contentView.transform = CGAffineTransform(
+            translationX: 0,
+            y: contentView.bounds.height + 300
+        )
+
+        UIView.animate(
+            withDuration: 0.35,
+            delay: 0,
+            options: .curveEaseOut
+        ) {
+            self.mainView.dimmingView.alpha = 1
+            contentView.transform = .identity
+        }
+    }
+
+    /// 바텀 시트 소멸
+    func animateOut(completion: @escaping () -> Void) {
+        view.layoutIfNeeded()
+        let contentView = mainView.contentView
+
+        UIView.animate(
+            withDuration: 0.3,
+            delay: 0,
+            options: .curveEaseIn,
+            animations: {
+                self.mainView.dimmingView.alpha = 0
+                contentView.transform = CGAffineTransform(
+                    translationX: 0,
+                    y: contentView.bounds.height + 300
+                )
+            },
+            completion: { _ in
+                completion()
+            }
+        )
+    }
+}
+
+//MARK: - Pan Gesture
+private extension ProductGroupListViewController {
+    /// contentView에 pan gesture 추가
+    func addPanGesture() {
+        let pan = UIPanGestureRecognizer(
+            target: self,
+            action: #selector(handlePan(_:))
+        )
+        pan.cancelsTouchesInView = false
+        mainView.contentView.addGestureRecognizer(pan)
+    }
+
+    /// gesture 상태에 따라 drag dismiss 적용
+    @objc
+    func handlePan(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: mainView.contentView)
+        let velocity = gesture.velocity(in: mainView.contentView)
+        let contentView = mainView.contentView
+        let contentHeight = contentView.bounds.height
+
+        switch gesture.state {
+        case .changed:
+            let offsetY = max(0, translation.y)
+            contentView.transform = CGAffineTransform(
+                translationX: 0,
+                y: offsetY
+            )
+            mainView.dimmingView.alpha = max(0, 1 - offsetY / contentHeight)
+
+        case .ended, .cancelled:
+            let offsetY = max(0, translation.y)
+            let shouldDismiss = offsetY > contentHeight * 0.35 || velocity.y > 800
+
+            if shouldDismiss {
+                close()
+            } else {
+                UIView.animate(
+                    withDuration: 0.3,
+                    delay: 0,
+                    usingSpringWithDamping: 0.8,
+                    initialSpringVelocity: 0.5
+                ) {
+                    contentView.transform = .identity
+                    self.mainView.dimmingView.alpha = 1
+                }
+            }
+
+        default:
+            break
+        }
+    }
+}

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -84,7 +84,7 @@ private extension StockViewController {
         
         productCollectionView.itemSelected
             .bind(onNext: { [weak self] item in
-                self?.delegate?.didSelectProduct(productID: item.product.id)
+                self?.selectProduct(item)
             })
             .disposed(by: disposeBag)
         
@@ -196,6 +196,29 @@ private extension StockViewController {
     ) {
         let viewController = CategorySelectionViewController(items: items)
         viewController.onApply = onApply
+        present(viewController, animated: false)
+    }
+    
+    /// 상품 선택
+    func selectProduct(_ item: ProductCellItem) {
+        guard item.isGrouped else {
+            delegate?.didSelectProduct(productID: item.product.id)
+            return
+        }
+        
+        presentProductGroupList(item)
+    }
+    
+    /// 그룹 상품 목록 모달 표시
+    func presentProductGroupList(_ item: ProductCellItem) {
+        let viewController = ProductGroupListViewController(
+            viewModel: ProductGroupListViewModel(items: item.groupedItems)
+        )
+        
+        viewController.onSelect = { [weak self] productID in
+            self?.delegate?.didSelectProduct(productID: productID)
+        }
+        
         present(viewController, animated: false)
     }
 }

--- a/JaengYeo/JaengYeo/ViewModel/Stock/ProductGroupListViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/ProductGroupListViewModel.swift
@@ -1,0 +1,59 @@
+//
+//  ProductGroupListViewModel.swift
+//  JaengYeo
+//
+//  Created by Codex on 4/19/26.
+//
+
+import Foundation
+import RxSwift
+
+final class ProductGroupListViewModel: ViewModelProtocol {
+
+    //MARK: - Properties
+    /// 그룹 상품 목록
+    private let items: [ProductCellItem]
+
+    struct Input {
+        /// 화면 로드 이벤트
+        let viewDidLoad: Observable<Void>
+        /// 상품 선택 이벤트
+        let itemSelected: Observable<ProductCellItem>
+    }
+
+    struct Output {
+        /// 총 수량 텍스트
+        let totalCountText: Observable<String>
+        /// 그룹 상품 목록
+        let items: Observable<[ProductCellItem]>
+        /// 선택된 상품 ID
+        let selectedProductID: Observable<UUID>
+    }
+
+    //MARK: - Init
+    init(items: [ProductCellItem]) {
+        self.items = items
+    }
+
+    func transform(_ input: Input) -> Output {
+        let items = input.viewDidLoad
+            .map { [items] in items }
+
+        let selectedProductID = input.itemSelected
+            .map { $0.product.id }
+
+        return Output(
+            totalCountText: .just("총 \(totalQuantity)개"),
+            items: items,
+            selectedProductID: selectedProductID
+        )
+    }
+}
+
+//MARK: - Data
+private extension ProductGroupListViewModel {
+    /// 총 수량
+    var totalQuantity: Int {
+        items.reduce(0) { $0 + $1.product.quantity }
+    }
+}

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
@@ -31,6 +31,26 @@ struct ProductCellItem: Hashable {
     let product: Product
     let midCategory: String?
     let subCategory: String?
+    let groupedCount: Int
+    let totalQuantity: Int
+    
+    init(
+        product: Product,
+        midCategory: String?,
+        subCategory: String?,
+        groupedCount: Int = 1,
+        totalQuantity: Int? = nil
+    ) {
+        self.product = product
+        self.midCategory = midCategory
+        self.subCategory = subCategory
+        self.groupedCount = groupedCount
+        self.totalQuantity = totalQuantity ?? product.quantity
+    }
+    
+    var displayTitle: String {
+        "\(product.name) (\(groupedCount)건)"
+    }
 }
 
 final class StockViewModel:  NSObject, ViewModelProtocol {
@@ -393,7 +413,7 @@ extension StockViewModel: NSFetchedResultsControllerDelegate {
                 )
             } ?? []
 
-        productsRelay.accept(sortProducts(products))
+        productsRelay.accept(sortProducts(groupProducts(products)))
     }
     
     /// 중분류 아이템 변환 및 반영
@@ -469,9 +489,55 @@ private extension StockViewModel {
                 )
             }
         case .quantityDesc:
-            return products.sorted { $0.product.quantity > $1.product.quantity }
+            return products.sorted { $0.totalQuantity > $1.totalQuantity }
         case .quantityAsc:
-            return products.sorted { $0.product.quantity < $1.product.quantity }
+            return products.sorted { $0.totalQuantity < $1.totalQuantity }
+        }
+    }
+    
+    /// 같은 이름 상품 묶기
+    func groupProducts(_ products: [ProductCellItem]) -> [ProductCellItem] {
+        let groupedProducts = Dictionary(grouping: products) {
+            $0.product.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+        }
+        
+        return groupedProducts.values.map { items in
+            guard let representative = makeRepresentativeItem(from: items) else {
+                return items[0]
+            }
+            
+            return ProductCellItem(
+                product: representative.product,
+                midCategory: representative.midCategory,
+                subCategory: representative.subCategory,
+                groupedCount: items.count,
+                totalQuantity: items.reduce(0) { $0 + $1.product.quantity }
+            )
+        }
+    }
+    
+    /// 그룹 대표 상품 선택
+    func makeRepresentativeItem(
+        from items: [ProductCellItem]
+    ) -> ProductCellItem? {
+        let itemsWithExpiryDate = items.filter {
+            $0.product.expiryDate != nil
+        }
+        
+        if !itemsWithExpiryDate.isEmpty {
+            return itemsWithExpiryDate.min {
+                guard
+                    let lhsDate = $0.product.expiryDate,
+                    let rhsDate = $1.product.expiryDate
+                else { return false }
+                
+                return lhsDate < rhsDate
+            }
+        }
+        
+        return items.max {
+            $0.product.createdAt < $1.product.createdAt
         }
     }
     

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
@@ -33,23 +33,34 @@ struct ProductCellItem: Hashable {
     let subCategory: String?
     let groupedCount: Int
     let totalQuantity: Int
+    let groupedItems: [ProductCellItem]
     
     init(
         product: Product,
         midCategory: String?,
         subCategory: String?,
         groupedCount: Int = 1,
-        totalQuantity: Int? = nil
+        totalQuantity: Int? = nil,
+        groupedItems: [ProductCellItem] = []
     ) {
         self.product = product
         self.midCategory = midCategory
         self.subCategory = subCategory
         self.groupedCount = groupedCount
         self.totalQuantity = totalQuantity ?? product.quantity
+        self.groupedItems = groupedItems
     }
     
     var displayTitle: String {
-        "\(product.name) (\(groupedCount)건)"
+        if isGrouped {
+            return "\(product.name) (\(groupedCount)건)"
+        }
+        
+        return product.name
+    }
+    
+    var isGrouped: Bool {
+        groupedCount > 1
     }
 }
 
@@ -503,7 +514,9 @@ private extension StockViewModel {
         }
         
         return groupedProducts.values.map { items in
-            guard let representative = makeRepresentativeItem(from: items) else {
+            let sortedGroupItems = sortGroupItems(items)
+            
+            guard let representative = makeRepresentativeItem(from: sortedGroupItems) else {
                 return items[0]
             }
             
@@ -512,7 +525,8 @@ private extension StockViewModel {
                 midCategory: representative.midCategory,
                 subCategory: representative.subCategory,
                 groupedCount: items.count,
-                totalQuantity: items.reduce(0) { $0 + $1.product.quantity }
+                totalQuantity: items.reduce(0) { $0 + $1.product.quantity },
+                groupedItems: sortedGroupItems
             )
         }
     }
@@ -538,6 +552,17 @@ private extension StockViewModel {
         
         return items.max {
             $0.product.createdAt < $1.product.createdAt
+        }
+    }
+    
+    /// 그룹 내 상품 정렬
+    func sortGroupItems(_ items: [ProductCellItem]) -> [ProductCellItem] {
+        items.sorted {
+            compareOptionalDate(
+                $0.product.expiryDate,
+                $1.product.expiryDate,
+                ascending: true
+            )
         }
     }
     


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #89 

## 🛠 작업 내용 (What I did)
- 그룹 상품 선택 시 목록 모달 화면(ProductGroupList) 추가
- 그룹 상품을 개별 선택할 수 있는 흐름 구현
- ProductGroupListView / ViewController / ViewModel 신규 구성
- DiffableDataSource 기반 컬렉션뷰 구조 적용
- View / VC / ViewModel 역할 분리 구조로 리팩토링

## 💻 구현 상세 (Implementation Details)
- ProductCellItem에 groupedItems 기반 그룹 데이터 전달 구조 활용
- 그룹 상품 선택 시 단일/그룹 분기 처리 후 모달 표시
- ProductGroupListView에서 datasource, snapshot, selection 이벤트 직접 관리
- ProductGroupListViewController는 바인딩 및 화면 제어(애니메이션, dismiss)만 담당
- ProductGroupListViewModel은 데이터 전달 및 선택 이벤트 처리만 수행하도록 경량화
- 선택된 상품 ID는 onSelect 콜백을 통해 상위로 전달

