### PR TITLE
[FEAT] 재고화면 상품 리스트 사이드 버튼 추가 #99

### DIFF
--- a/JaengYeo/JaengYeo/Model/Domain/CoreData/Product.swift
+++ b/JaengYeo/JaengYeo/Model/Domain/CoreData/Product.swift
@@ -64,3 +64,34 @@ extension Product {
         )
     }
 }
+
+extension Product {
+    /// 재고가 1개 차감된 상품 생성
+    func decreasedQuantity() -> Product {
+        Product(
+            id: id,
+            userId: userId,
+            name: name,
+            quantity: quantity - 1,
+            quantityUnit: quantityUnit,
+            mainCategory: mainCategory,
+            midCategoryId: midCategoryId,
+            subCategoryId: subCategoryId,
+            purchaseDate: purchaseDate,
+            expiryDate: expiryDate,
+            price: price,
+            locationMemo: locationMemo,
+            memo: memo,
+            imageUrl: imageUrl,
+            isClassified: isClassified,
+            lowStockThreshold: lowStockThreshold,
+            isFavorite: isFavorite,
+            createdAt: createdAt,
+            updatedAt: Date(),
+            syncStatus: SyncStatus.pendingUpload.rawValue,
+            isLowStockNotificationEnabled: isLowStockNotificationEnabled,
+            caution: caution,
+            brand: brand
+        )
+    }
+}

--- a/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
@@ -16,6 +16,8 @@ final class ProductCollectionView: UIView {
     //MARK: - Properties
     private let disposeBag = DisposeBag()
     private let itemSelectedRelay = PublishRelay<ProductCellItem>()
+    private let swipeDeleteRelay = PublishRelay<IndexPath>()
+    private let itemDeletedRelay = PublishRelay<ProductCellItem>()
     private lazy var dataSource = configureDataSource()
 
     //MARK: - Components
@@ -99,6 +101,11 @@ extension ProductCollectionView {
     var itemSelected: Observable<ProductCellItem> {
         itemSelectedRelay.asObservable()
     }
+    
+    /// 상품 셀 삭제 이벤트
+    var itemDeleted: Observable<ProductCellItem> {
+        itemDeletedRelay.asObservable()
+    }
 
     /// 스냅샷 적용
     func applySnapshot(with productDatas: [ProductCellItem]) {
@@ -178,31 +185,38 @@ private extension ProductCollectionView {
 private extension ProductCollectionView {
     /// 컬렉션 뷰 레이아웃 생성
     func createLayout() -> UICollectionViewLayout {
-        let item = NSCollectionLayoutItem(
-            layoutSize: .init(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(88)
+        UICollectionViewCompositionalLayout { _, environment in
+            var configuration = UICollectionLayoutListConfiguration(
+                appearance: .plain
             )
-        )
+            configuration.showsSeparators = false
+            configuration.backgroundColor = .clear
+            configuration.trailingSwipeActionsConfigurationProvider = {
+                [weak self] indexPath in
+                let deleteAction = UIContextualAction(
+                    style: .destructive,
+                    title: nil
+                ) { [weak self] _, _, completion in
+                    self?.swipeDeleteRelay.accept(indexPath)
+                    completion(true)
+                }
+                deleteAction.image = UIImage(systemName: "trash")
+                return UISwipeActionsConfiguration(actions: [deleteAction])
+            }
 
-        let group = NSCollectionLayoutGroup.vertical(
-            layoutSize: .init(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(88)
-            ),
-            subitems: [item]
-        )
-
-        let section = NSCollectionLayoutSection(group: group)
-        section.interGroupSpacing = 8
-        section.contentInsets = NSDirectionalEdgeInsets(
-            top: 0,
-            leading: 16,
-            bottom: 0,
-            trailing: 16
-        )
-
-        return UICollectionViewCompositionalLayout(section: section)
+            let section = NSCollectionLayoutSection.list(
+                using: configuration,
+                layoutEnvironment: environment
+            )
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top: 0,
+                leading: 16,
+                bottom: 0,
+                trailing: 16
+            )
+            section.interGroupSpacing = 8
+            return section
+        }
     }
 }
 
@@ -258,6 +272,13 @@ private extension ProductCollectionView {
                 self?.dataSource.itemIdentifier(for: indexPath)
             }
             .bind(to: itemSelectedRelay)
+            .disposed(by: disposeBag)
+        
+        swipeDeleteRelay
+            .compactMap { [weak self] indexPath in
+                self?.dataSource.itemIdentifier(for: indexPath)
+            }
+            .bind(to: itemDeletedRelay)
             .disposed(by: disposeBag)
     }
 }

--- a/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductCollectionView.swift
@@ -16,7 +16,9 @@ final class ProductCollectionView: UIView {
     //MARK: - Properties
     private let disposeBag = DisposeBag()
     private let itemSelectedRelay = PublishRelay<ProductCellItem>()
+    private let swipeDecreaseRelay = PublishRelay<IndexPath>()
     private let swipeDeleteRelay = PublishRelay<IndexPath>()
+    private let itemQuantityDecreasedRelay = PublishRelay<ProductCellItem>()
     private let itemDeletedRelay = PublishRelay<ProductCellItem>()
     private lazy var dataSource = configureDataSource()
 
@@ -100,6 +102,11 @@ extension ProductCollectionView {
     /// 상품 셀 선택 이벤트
     var itemSelected: Observable<ProductCellItem> {
         itemSelectedRelay.asObservable()
+    }
+    
+    /// 상품 재고 차감 이벤트
+    var itemQuantityDecreased: Observable<ProductCellItem> {
+        itemQuantityDecreasedRelay.asObservable()
     }
     
     /// 상품 셀 삭제 이벤트
@@ -201,7 +208,15 @@ private extension ProductCollectionView {
                     completion(true)
                 }
                 deleteAction.image = UIImage(systemName: "trash")
-                return UISwipeActionsConfiguration(actions: [deleteAction])
+                
+                let actions = self?.makeSwipeActions(
+                    indexPath: indexPath,
+                    deleteAction: deleteAction
+                ) ?? [deleteAction]
+                
+                let configuration = UISwipeActionsConfiguration(actions: actions)
+                configuration.performsFirstActionWithFullSwipe = false
+                return configuration
             }
 
             let section = NSCollectionLayoutSection.list(
@@ -258,6 +273,40 @@ private extension ProductCollectionView {
     }
 }
 
+//MARK: - Action State
+private extension ProductCollectionView {
+    /// 스와이프 액션 목록 생성
+    func makeSwipeActions(
+        indexPath: IndexPath,
+        deleteAction: UIContextualAction
+    ) -> [UIContextualAction] {
+        guard canDecreaseQuantity(at: indexPath) else {
+            return [deleteAction]
+        }
+        
+        let decreaseAction = UIContextualAction(
+            style: .normal,
+            title: ""
+        ) { [weak self] _, _, completion in
+            self?.swipeDecreaseRelay.accept(indexPath)
+            completion(false)
+        }
+        decreaseAction.image = UIImage(systemName: "minus")
+        decreaseAction.backgroundColor = .accent
+        
+        return [deleteAction, decreaseAction]
+    }
+    
+    /// 재고 차감 가능 여부
+    func canDecreaseQuantity(at indexPath: IndexPath) -> Bool {
+        guard let item = dataSource.itemIdentifier(for: indexPath) else {
+            return false
+        }
+        
+        return item.product.quantity > 0
+    }
+}
+
 //MARK: - Binding
 private extension ProductCollectionView {
     func bind() {
@@ -272,6 +321,13 @@ private extension ProductCollectionView {
                 self?.dataSource.itemIdentifier(for: indexPath)
             }
             .bind(to: itemSelectedRelay)
+            .disposed(by: disposeBag)
+        
+        swipeDecreaseRelay
+            .compactMap { [weak self] indexPath in
+                self?.dataSource.itemIdentifier(for: indexPath)
+            }
+            .bind(to: itemQuantityDecreasedRelay)
             .disposed(by: disposeBag)
         
         swipeDeleteRelay

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -77,6 +77,8 @@ private extension StockViewController {
         let subCategoryAppliedRelay = PublishRelay<[String]>()
         /// 상품 정렬 선택
         let sortOptionSelectedRelay = PublishRelay<ProductSortOption>()
+        /// 상품 재고 차감 선택
+        let productQuantityDecreasedRelay = PublishRelay<ProductCellItem>()
         /// 상품 삭제 선택
         let productDeletedRelay = PublishRelay<[UUID]>()
         
@@ -88,6 +90,10 @@ private extension StockViewController {
             .bind(onNext: { [weak self] item in
                 self?.selectProduct(item)
             })
+            .disposed(by: disposeBag)
+        
+        productCollectionView.itemQuantityDecreased
+            .bind(to: productQuantityDecreasedRelay)
             .disposed(by: disposeBag)
         
         productCollectionView.itemDeleted
@@ -109,6 +115,7 @@ private extension StockViewController {
             midCategoryApplied: midCategoryAppliedRelay.asObservable(),
             subCategoryApplied: subCategoryAppliedRelay.asObservable(),
             sortOptionSelected: sortOptionSelectedRelay.asObservable(),
+            productQuantityDecreased: productQuantityDecreasedRelay.asObservable(),
             productDeleted: productDeletedRelay.asObservable()
         )
         

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -77,6 +77,8 @@ private extension StockViewController {
         let subCategoryAppliedRelay = PublishRelay<[String]>()
         /// 상품 정렬 선택
         let sortOptionSelectedRelay = PublishRelay<ProductSortOption>()
+        /// 상품 삭제 선택
+        let productDeletedRelay = PublishRelay<[UUID]>()
         
         productCollectionView.configureSortMenu { sortOption in
             sortOptionSelectedRelay.accept(sortOption)
@@ -86,6 +88,14 @@ private extension StockViewController {
             .bind(onNext: { [weak self] item in
                 self?.selectProduct(item)
             })
+            .disposed(by: disposeBag)
+        
+        productCollectionView.itemDeleted
+            .flatMapLatest { [weak self] item -> Observable<[UUID]> in
+                guard let self else { return .empty() }
+                return self.showDeleteAlert(item: item)
+            }
+            .bind(to: productDeletedRelay)
             .disposed(by: disposeBag)
         
         /// ViewModel 입력값
@@ -98,7 +108,8 @@ private extension StockViewController {
             subCategoryTapped: categoryFilterView.subCategoryButton.rx.tap.asObservable(),
             midCategoryApplied: midCategoryAppliedRelay.asObservable(),
             subCategoryApplied: subCategoryAppliedRelay.asObservable(),
-            sortOptionSelected: sortOptionSelectedRelay.asObservable()
+            sortOptionSelected: sortOptionSelectedRelay.asObservable(),
+            productDeleted: productDeletedRelay.asObservable()
         )
         
         /// 카테고리 편집 버튼 바인딩
@@ -220,6 +231,39 @@ private extension StockViewController {
         }
         
         present(viewController, animated: false)
+    }
+    
+    /// 상품 삭제 알럿 표시
+    func showDeleteAlert(item: ProductCellItem) -> Observable<[UUID]> {
+        let productIDs = item.deleteTargetProductIDs
+        
+        return AlertController.rx.alert(
+            on: self,
+            image: UIImage(named: "alartRed") ?? UIImage(),
+            title: "상품 삭제",
+            message:  item.isGrouped
+            ? "같은 이름의 상품 \(item.groupedCount)건을 삭제하시겠습니까?"
+            : "해당 상품을 삭제하시겠습니까?",
+            actions: [
+                .cancel("취소"),
+                .destructive("삭제")
+            ]
+        )
+        .filter { $0.title == "삭제" }
+        .map { _ in productIDs }
+        .asObservable()
+    }
+}
+
+//MARK: - ProductCellItem
+private extension ProductCellItem {
+    /// 삭제 대상 상품 ID 목록
+    var deleteTargetProductIDs: [UUID] {
+        if isGrouped {
+            return groupedItems.map { $0.product.id }
+        }
+        
+        return [product.id]
     }
 }
 

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
@@ -111,6 +111,8 @@ final class StockViewModel:  NSObject, ViewModelProtocol {
         let subCategoryApplied: Observable<[String]>
         /// 상품 정렬 선택 이벤트
         let sortOptionSelected: Observable<ProductSortOption>
+        /// 상품 재고 차감 이벤트
+        let productQuantityDecreased: Observable<ProductCellItem>
         /// 상품 삭제 이벤트
         let productDeleted: Observable<[UUID]>
     }
@@ -199,6 +201,14 @@ final class StockViewModel:  NSObject, ViewModelProtocol {
                 guard let self else { return }
                 self.selectedSortOptionRelay.accept(sortOption)
                 self.updateProducts()
+            })
+            .disposed(by: disposeBag)
+        
+        /// 상품 재고 차감
+        input.productQuantityDecreased
+            .subscribe(onNext: { [weak self] item in
+                guard let self else { return }
+                self.decreaseProductQuantity(item.product)
             })
             .disposed(by: disposeBag)
         
@@ -595,8 +605,24 @@ private extension StockViewModel {
     }
 }
 
+
 //MARK: - Delete
 private extension StockViewModel {
+    /// 상품 재고 1개 차감
+    func decreaseProductQuantity(_ product: Product) {
+        guard product.quantity > 0 else { return }
+        
+        do {
+            try coreDataManager.updateProduct(
+                product
+                    .decreasedQuantity()
+                    .toPayload()
+            )
+            performFetch()
+        } catch {
+        }
+    }
+
     /// 상품 삭제
     func deleteProducts(_ productIDs: [UUID]) {
         productIDs.forEach {

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
@@ -111,6 +111,8 @@ final class StockViewModel:  NSObject, ViewModelProtocol {
         let subCategoryApplied: Observable<[String]>
         /// 상품 정렬 선택 이벤트
         let sortOptionSelected: Observable<ProductSortOption>
+        /// 상품 삭제 이벤트
+        let productDeleted: Observable<[UUID]>
     }
     
     struct Output {
@@ -197,6 +199,14 @@ final class StockViewModel:  NSObject, ViewModelProtocol {
                 guard let self else { return }
                 self.selectedSortOptionRelay.accept(sortOption)
                 self.updateProducts()
+            })
+            .disposed(by: disposeBag)
+        
+        /// 상품 삭제
+        input.productDeleted
+            .subscribe(onNext: { [weak self] productIDs in
+                guard let self else { return }
+                self.deleteProducts(productIDs)
             })
             .disposed(by: disposeBag)
         
@@ -582,5 +592,16 @@ private extension StockViewModel {
         case (.none, .none):
             return false
         }
+    }
+}
+
+//MARK: - Delete
+private extension StockViewModel {
+    /// 상품 삭제
+    func deleteProducts(_ productIDs: [UUID]) {
+        productIDs.forEach {
+            try? coreDataManager.softDeleteProduct(id: $0)
+        }
+        performFetch()
     }
 }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #99
Closes #22

## 🛠 작업 내용 (What I did)
- 재고 목록 셀에 trailing swipe action 추가
- 스와이프 삭제 기능 구현
- 스와이프 재고 차감 기능 구현
- 삭제 전 확인 알럿 추가
- 그룹 상품 삭제 시 포함된 상품 전체 삭제 처리
- 재고 차감 시 상품 수량 1개 감소 처리


## 💻 구현 상세 (Implementation Details)
### ProductCollectionView
- list configuration 기반 swipe action 적용
- 삭제 액션과 차감 액션 추가
- 재고가 1개 이상일 때만 차감 액션 노출
- swipe 이벤트를 Rx Observable로 외부 전달

### StockViewController
- 삭제 선택 시 `AlertController` 확인 알럿 표시
- 삭제 확정 후 상품 ID 목록을 ViewModel로 전달
- 차감 선택 시 대상 상품 정보를 ViewModel로 전달

### StockViewModel
- 삭제 대상 상품들을 `softDeleteProduct`로 처리
- 차감 대상 상품의 재고를 1개 감소
- `Product.toPayload()`를 재사용해 CoreData 업데이트 처리
- 수량이 0이 된 상품은 기존 `updateProduct` 로직에 따라 삭제 대기 처리
