### PR TITLE
♻️ refactor: BaseViewController ScrollView 자식 필터링 수정

### DIFF
--- a/JaengYeo/JaengYeo/View/Common/BaseViewController.swift
+++ b/JaengYeo/JaengYeo/View/Common/BaseViewController.swift
@@ -38,16 +38,16 @@ extension BaseViewController {
     @objc
     private func keyboardWillShow(_ notification: Notification) {
         guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
-              let scrollView = findScrollView(in: view) else { return }
+              let scrollView = findScrollView(in: view),
+              let activeField = view.findFirstResponder(),
+              activeField.isDescendant(of: scrollView) else { return }
         let inset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardFrame.height
                                  , right: 0)
         scrollView.contentInset = inset
         scrollView.scrollIndicatorInsets = inset
         
-        if let activeField = view.findFirstResponder() {
-            let rect = activeField.convert(activeField.bounds, to: scrollView)
-            scrollView.scrollRectToVisible(rect.insetBy(dx: 0, dy: -20), animated: true)
-        }
+        let rect = activeField.convert(activeField.bounds, to: scrollView)
+        scrollView.scrollRectToVisible(rect.insetBy(dx: 0, dy: -20), animated: true)
     }
     
     @objc


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #

## 🛠 작업 내용 (What I did)
- 키보드가 사용되는 곳에서 스크롤뷰에 따라 필터링하지 않고 스크롤 시키는 버그 확인
- 스크롤뷰가 존재하는 경우에만 스크롤이 가능하도록 수정


## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
