### PR TITLE
Fix/barcode#119

### DIFF
--- a/JaengYeo/JaengYeo/View/Register/RegisterViewController.swift
+++ b/JaengYeo/JaengYeo/View/Register/RegisterViewController.swift
@@ -202,9 +202,13 @@ extension RegisterViewController {
         output.isLoading
             .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak self] isLoading in
-                if !isLoading { self?.isBarcodeLocked = false }
-                isLoading ? self?.mainView.startScanAnimation() : self?.mainView.stopScanAnimation()
-                self?.mainView.captureButton.isEnabled = !isLoading
+                guard let self else { return }
+                if !isLoading { self.isBarcodeLocked = false }
+                isLoading ? self.mainView.startScanAnimation() : self.mainView.stopScanAnimation()
+                self.mainView.captureButton.isEnabled = !isLoading
+                self.sessionQueue.async {
+                    isLoading ? self.captureSession.stopRunning() : self.captureSession.startRunning()
+                }
             })
             .disposed(by: disposeBag)
         

--- a/JaengYeo/JaengYeo/View/Register/RegisterViewController.swift
+++ b/JaengYeo/JaengYeo/View/Register/RegisterViewController.swift
@@ -40,6 +40,8 @@ final class RegisterViewController: UIViewController {
     
     private var currentMode: CameraMode = .barcode
     
+    private var frozenImageView: UIImageView?
+    
     init(viewModel: RegisterViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -203,12 +205,17 @@ extension RegisterViewController {
             .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak self] isLoading in
                 guard let self else { return }
-                if !isLoading { self.isBarcodeLocked = false }
+                if !isLoading {
+                    self.isBarcodeLocked = false
+                    self.restartPreview()
+                    if self.currentMode == .barcode {
+                        self.sessionQueue.async {
+                            self.captureSession.startRunning()
+                        }
+                    }
+                }
                 isLoading ? self.mainView.startScanAnimation() : self.mainView.stopScanAnimation()
                 self.mainView.captureButton.isEnabled = !isLoading
-                self.sessionQueue.async {
-                    isLoading ? self.captureSession.stopRunning() : self.captureSession.startRunning()
-                }
             })
             .disposed(by: disposeBag)
         
@@ -350,6 +357,8 @@ extension RegisterViewController: AVCapturePhotoCaptureDelegate {
               let data = photo.fileDataRepresentation(),
               let image = UIImage(data: data) else { return }
         
+        stopPreview(image: image)
+        
         switch currentMode {
         case .receipt:
             let resizedImage = image.resized(maxDimension: 1024)
@@ -393,6 +402,24 @@ extension RegisterViewController: AVCaptureMetadataOutputObjectsDelegate {
             .compactMap { $0.stringValue }
         guard !codes.isEmpty else { return }
         isBarcodeLocked = true
+        sessionQueue.async {
+            self.captureSession.stopRunning()
+        }
         barcodeCapturedSubject.onNext(codes)
+    }
+}
+
+extension RegisterViewController {
+    private func stopPreview(image: UIImage) {
+        let imageView = UIImageView(image: image)
+        imageView.frame = mainView.previewView.bounds
+        imageView.contentMode = .scaleAspectFill
+        mainView.previewView.addSubview(imageView)
+        frozenImageView = imageView
+    }
+    
+    private func restartPreview() {
+        frozenImageView?.removeFromSuperview()
+        frozenImageView = nil
     }
 }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #

## 🛠 작업 내용 (What I did)
- output.isLoading 시에 captureSession의 stop/start 조건 정의
- 바코드: 촬영 버튼이 따로 없어 session을 stop/start
- 영수증, AI 인식: 촬영 시 캡쳐된 이미지를 UIImageView로 프리뷰 위에 얹음

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
