### PR TITLE
입력 안정성 보강 및 상세/재고 화면 UI 동작 개선

### DIFF
--- a/JaengYeo/JaengYeo/Model/Domain/CoreData/Product.swift
+++ b/JaengYeo/JaengYeo/Model/Domain/CoreData/Product.swift
@@ -35,6 +35,8 @@ struct Product: Hashable {
 
 //MARK: - Method
 extension Product {
+    static let maxQuantity = 999
+
     /// Product -> ProductPayload 변환 메소드
     func toPayload() -> ProductPayload {
         ProductPayload(
@@ -72,7 +74,7 @@ extension Product {
             id: id,
             userId: userId,
             name: name,
-            quantity: quantity + 1,
+            quantity: min(quantity + 1, Self.maxQuantity),
             quantityUnit: quantityUnit,
             mainCategory: mainCategory,
             midCategoryId: midCategoryId,

--- a/JaengYeo/JaengYeo/Utils/Base/StyledButton.swift
+++ b/JaengYeo/JaengYeo/Utils/Base/StyledButton.swift
@@ -90,8 +90,7 @@ extension StyledButton {
             string: title,
             attributes: [
                 .font: config.font,
-                .foregroundColor: config.normalColor,
-                .kern: config.kern
+                .foregroundColor: config.normalColor
             ]
         )
         
@@ -99,8 +98,7 @@ extension StyledButton {
             string: title,
             attributes: [
                 .font: config.font,
-                .foregroundColor: config.selectedColor,
-                .kern: config.kern
+                .foregroundColor: config.selectedColor
             ]
         )
         
@@ -108,8 +106,7 @@ extension StyledButton {
             string: title,
             attributes: [
                 .font: config.font,
-                .foregroundColor: config.disabledColor,
-                .kern: config.kern
+                .foregroundColor: config.disabledColor
             ]
         )
         

--- a/JaengYeo/JaengYeo/Utils/Base/StyledLabel.swift
+++ b/JaengYeo/JaengYeo/Utils/Base/StyledLabel.swift
@@ -51,8 +51,7 @@ extension StyledLabel{
             string: text,
             attributes: [
                 .font: config.font,
-                .foregroundColor: config.color,
-                .kern: config.kern
+                .foregroundColor: config.color
             ]
         )
     }

--- a/JaengYeo/JaengYeo/Utils/Configuration/ButtonConfiguration.swift
+++ b/JaengYeo/JaengYeo/Utils/Configuration/ButtonConfiguration.swift
@@ -12,7 +12,6 @@ struct ButtonTitleConfiguration {
     let normalColor: UIColor
     let selectedColor: UIColor
     let disabledColor: UIColor
-    let kern: CGFloat
     
     /// 색상 변환 메소드
     func updatingColor(
@@ -24,8 +23,7 @@ struct ButtonTitleConfiguration {
                font: font,
                normalColor: normalColor ?? self.normalColor,
                selectedColor: selectedColor ?? self.selectedColor,
-               disabledColor: disabledColor ?? self.disabledColor,
-               kern: kern
+               disabledColor: disabledColor ?? self.disabledColor
            )
        }
 }
@@ -70,40 +68,35 @@ extension ButtonTitleConfiguration {
         font: .systemFont(ofSize: 14, weight: .bold),
         normalColor: .accent,
         selectedColor: .white,
-        disabledColor: .gray500,
-        kern: -0.15
+        disabledColor: .gray500
     )
     
     static let textTitle12 = ButtonTitleConfiguration (
         font: .systemFont(ofSize: 12, weight: .regular),
         normalColor: .accent,
         selectedColor: .white,
-        disabledColor: .gray500,
-        kern: -0.15
+        disabledColor: .gray500
     )
     
     static let textGrayTitle12 = ButtonTitleConfiguration (
         font: .systemFont(ofSize: 12, weight: .regular),
         normalColor: .gray800,
         selectedColor: .white,
-        disabledColor: .gray800,
-        kern: -0.15
+        disabledColor: .gray800
     )
 
     static let resetTitle = ButtonTitleConfiguration(
         font: .systemFont(ofSize: 14, weight: .medium),
         normalColor: .gray300,
         selectedColor: .gray300,
-        disabledColor: .gray300,
-        kern: -0.15
+        disabledColor: .gray300
     )
     
     static let defaultTitle = ButtonTitleConfiguration (
         font: .systemFont(ofSize: 14, weight: .medium),
         normalColor: .white,
         selectedColor: .white,
-        disabledColor: .gray500,
-        kern: -0.15
+        disabledColor: .gray500
     )
     
     /// 메인 컬러 텍스트 설정
@@ -111,32 +104,28 @@ extension ButtonTitleConfiguration {
         font: .systemFont(ofSize: 14, weight: .bold),
         normalColor: .gray500,
         selectedColor: .accent,
-        disabledColor: .white,
-        kern: -0.15
+        disabledColor: .white
     )
     
     static let redTitle = ButtonTitleConfiguration (
         font: .systemFont(ofSize: 14, weight: .medium),
         normalColor: .primaryRed,
         selectedColor: .white,
-        disabledColor: .gray500,
-        kern: -0.15
+        disabledColor: .gray500
     )
     
     static let categoryTitle = ButtonTitleConfiguration (
         font: .systemFont(ofSize: 12, weight: .regular),
         normalColor: .gray800,
         selectedColor: .accent,
-        disabledColor: .white,
-        kern: -0.15
+        disabledColor: .white
     )
     
     static let cancelTitle = ButtonTitleConfiguration (
         font: .systemFont(ofSize: 12, weight: .regular),
         normalColor: .gray800,
         selectedColor: .gray300,
-        disabledColor: .white,
-        kern: -0.15
+        disabledColor: .white
     )
 }
 

--- a/JaengYeo/JaengYeo/Utils/Configuration/LabelConfiguration.swift
+++ b/JaengYeo/JaengYeo/Utils/Configuration/LabelConfiguration.swift
@@ -16,16 +16,13 @@ struct LabelConfiguration {
     let color: UIColor
     /// 라인갯수
     let lines: Int
-    /// 텍스트 자간 값
-    let kern: CGFloat
     
     /// 색상 변경 메소드
     func updatingColor(color: UIColor) -> LabelConfiguration {
         .init(
             font: font,
             color: color,
-            lines: lines,
-            kern: kern
+            lines: lines
         )
     }
 }
@@ -42,43 +39,37 @@ extension LabelConfiguration {
     static let titleBold28 = LabelConfiguration(
         font: .systemFont(ofSize: 28, weight: .bold),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
     
     static let titleBold24 = LabelConfiguration(
         font: .systemFont(ofSize: 24, weight: .bold),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
  
     static let titleBold20 = LabelConfiguration(
         font: .systemFont(ofSize: 20, weight: .bold),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
  
     static let titleSemi20 = LabelConfiguration(
         font: .systemFont(ofSize: 20, weight: .semibold),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
 
     static let titleSemi18 = LabelConfiguration(
         font: .systemFont(ofSize: 18, weight: .semibold),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
 
     static let titleSemi16 = LabelConfiguration(
         font: .systemFont(ofSize: 16, weight: .semibold),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
 }
 
@@ -88,28 +79,24 @@ extension LabelConfiguration {
     static let bodyMedium14 = LabelConfiguration(
         font: .systemFont(ofSize: 14, weight: .medium),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
     
     static let bodyMedium12 = LabelConfiguration(
         font: .systemFont(ofSize: 12, weight: .medium),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
  
     static let body14 = LabelConfiguration(
         font: .systemFont(ofSize: 14, weight: .regular),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
  
     static let body12 = LabelConfiguration(
         font: .systemFont(ofSize: 12, weight: .regular),
         color: .gray800,
-        lines: 0,
-        kern: -0.15
+        lines: 0
     )
 }

--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -108,7 +108,7 @@ final class ProductCell: UICollectionViewListCell{
     /// 메인 스택
     private let productMainStack = UIStackView().then {
         $0.axis = .horizontal
-        $0.spacing = 8
+        $0.spacing = 16
         $0.alignment = .center
         $0.distribution = .fill
     }

--- a/JaengYeo/JaengYeo/View/MyPage/MyPageView.swift
+++ b/JaengYeo/JaengYeo/View/MyPage/MyPageView.swift
@@ -148,7 +148,7 @@ extension MyPageView {
 
             let section = NSCollectionLayoutSection(group: group)
             section.boundarySupplementaryItems = [header]
-            section.interGroupSpacing = 8
+            section.interGroupSpacing = 16
             section.contentInsets = NSDirectionalEdgeInsets(
                 top: 8,
                 leading: 16,

--- a/JaengYeo/JaengYeo/View/OnBorading/OnboardingFifthView.swift
+++ b/JaengYeo/JaengYeo/View/OnBorading/OnboardingFifthView.swift
@@ -78,6 +78,7 @@ private extension OnboardingFifthView {
             $0.top.equalTo(firstImageView.snp.bottom).offset(72)
             $0.centerX.equalToSuperview()
             $0.size.equalTo(CGSize(width: 343, height: 88))
+            $0.bottom.equalToSuperview().inset(24)
         }
     }
 
@@ -89,8 +90,7 @@ private extension OnboardingFifthView {
             string: "\(primary)\n",
             attributes: [
                 .font: LabelConfiguration.titleSemi20.font,
-                .foregroundColor: UIColor.gray800,
-                .kern: LabelConfiguration.titleSemi20.kern
+                .foregroundColor: UIColor.gray800
             ]
         )
 
@@ -99,8 +99,7 @@ private extension OnboardingFifthView {
                 string: accent,
                 attributes: [
                     .font: LabelConfiguration.titleSemi20.font,
-                    .foregroundColor: UIColor.accent,
-                    .kern: LabelConfiguration.titleSemi20.kern
+                    .foregroundColor: UIColor.accent
                 ]
             )
         )
@@ -113,8 +112,7 @@ private extension OnboardingFifthView {
             string: text,
             attributes: [
                 .font: LabelConfiguration.body14.font,
-                .foregroundColor: UIColor.gray300,
-                .kern: LabelConfiguration.body14.kern
+                .foregroundColor: UIColor.gray300
             ]
         )
     }

--- a/JaengYeo/JaengYeo/View/OnBorading/OnboardingFirstView.swift
+++ b/JaengYeo/JaengYeo/View/OnBorading/OnboardingFirstView.swift
@@ -23,7 +23,7 @@ final class OnboardingFirstView: UIView {
     private let descriptionLabel = StyledLabel(config: .body14).then {
         $0.numberOfLines = 0
         $0.attributedText = OnboardingFirstView.makeDescription(
-            "쟁여에 물건을 쟁여두면,/n집 안의 재고를 한눈에 확인하고/n깔끔하게 정리할 수 있어요!"
+            "쟁여에 물건을 쟁여두면,\n집 안의 재고를 한눈에 확인하고\n깔끔하게 정리할 수 있어요!"
         )
     }
 
@@ -66,6 +66,7 @@ private extension OnboardingFirstView {
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(72)
             $0.centerX.equalToSuperview()
             $0.size.equalTo(CGSize(width: 285, height: 210))
+            $0.bottom.equalToSuperview().inset(24)
         }
     }
 
@@ -77,8 +78,7 @@ private extension OnboardingFirstView {
             string: "\(primary)\n",
             attributes: [
                 .font: LabelConfiguration.titleSemi20.font,
-                .foregroundColor: UIColor.gray800,
-                .kern: LabelConfiguration.titleSemi20.kern
+                .foregroundColor: UIColor.gray800
             ]
         )
 
@@ -87,8 +87,7 @@ private extension OnboardingFirstView {
                 string: accent,
                 attributes: [
                     .font: LabelConfiguration.titleSemi20.font,
-                    .foregroundColor: UIColor.accent,
-                    .kern: LabelConfiguration.titleSemi20.kern
+                    .foregroundColor: UIColor.accent
                 ]
             )
         )
@@ -101,8 +100,7 @@ private extension OnboardingFirstView {
             string: text,
             attributes: [
                 .font: LabelConfiguration.body14.font,
-                .foregroundColor: UIColor.gray300,
-                .kern: LabelConfiguration.body14.kern
+                .foregroundColor: UIColor.gray300
             ]
         )
     }

--- a/JaengYeo/JaengYeo/View/OnBorading/OnboardingFourthView.swift
+++ b/JaengYeo/JaengYeo/View/OnBorading/OnboardingFourthView.swift
@@ -66,6 +66,7 @@ private extension OnboardingFourthView {
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(40)
             $0.centerX.equalToSuperview()
             $0.size.equalTo(CGSize(width: 160, height: 346))
+            $0.bottom.equalToSuperview().inset(24)
         }
     }
 
@@ -77,8 +78,7 @@ private extension OnboardingFourthView {
             string: "\(primary)\n",
             attributes: [
                 .font: LabelConfiguration.titleSemi20.font,
-                .foregroundColor: UIColor.gray800,
-                .kern: LabelConfiguration.titleSemi20.kern
+                .foregroundColor: UIColor.gray800
             ]
         )
 
@@ -87,8 +87,7 @@ private extension OnboardingFourthView {
                 string: accent,
                 attributes: [
                     .font: LabelConfiguration.titleSemi20.font,
-                    .foregroundColor: UIColor.accent,
-                    .kern: LabelConfiguration.titleSemi20.kern
+                    .foregroundColor: UIColor.accent
                 ]
             )
         )
@@ -101,8 +100,7 @@ private extension OnboardingFourthView {
             string: text,
             attributes: [
                 .font: LabelConfiguration.body14.font,
-                .foregroundColor: UIColor.gray300,
-                .kern: LabelConfiguration.body14.kern
+                .foregroundColor: UIColor.gray300
             ]
         )
     }

--- a/JaengYeo/JaengYeo/View/OnBorading/OnboardingSecondView.swift
+++ b/JaengYeo/JaengYeo/View/OnBorading/OnboardingSecondView.swift
@@ -66,6 +66,7 @@ private extension OnboardingSecondView {
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(40)
             $0.centerX.equalToSuperview()
             $0.size.equalTo(CGSize(width: 160, height: 346))
+            $0.bottom.equalToSuperview().inset(24)
         }
     }
 
@@ -77,8 +78,7 @@ private extension OnboardingSecondView {
             string: "\(primary)\n",
             attributes: [
                 .font: LabelConfiguration.titleSemi20.font,
-                .foregroundColor: UIColor.gray800,
-                .kern: LabelConfiguration.titleSemi20.kern
+                .foregroundColor: UIColor.gray800
             ]
         )
 
@@ -87,8 +87,7 @@ private extension OnboardingSecondView {
                 string: accent,
                 attributes: [
                     .font: LabelConfiguration.titleSemi20.font,
-                    .foregroundColor: UIColor.accent,
-                    .kern: LabelConfiguration.titleSemi20.kern
+                    .foregroundColor: UIColor.accent
                 ]
             )
         )
@@ -101,8 +100,7 @@ private extension OnboardingSecondView {
             string: text,
             attributes: [
                 .font: LabelConfiguration.body14.font,
-                .foregroundColor: UIColor.gray300,
-                .kern: LabelConfiguration.body14.kern
+                .foregroundColor: UIColor.gray300
             ]
         )
     }

--- a/JaengYeo/JaengYeo/View/OnBorading/OnboardingThirdView.swift
+++ b/JaengYeo/JaengYeo/View/OnBorading/OnboardingThirdView.swift
@@ -43,8 +43,7 @@ final class OnboardingThirdView: UIView {
             string: "빠른 등록?",
             attributes: [
                 .font: LabelConfiguration.bodyMedium14.font,
-                .foregroundColor: UIColor.accent,
-                .kern: LabelConfiguration.bodyMedium14.kern
+                .foregroundColor: UIColor.accent
             ]
         )
     }
@@ -109,6 +108,7 @@ private extension OnboardingThirdView {
         bottomDescriptionLabel.snp.makeConstraints {
             $0.top.equalTo(bottomTitleLabel.snp.bottom).offset(2)
             $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().inset(24)
         }
     }
 
@@ -120,8 +120,7 @@ private extension OnboardingThirdView {
             string: "\(primary)\n",
             attributes: [
                 .font: LabelConfiguration.titleSemi20.font,
-                .foregroundColor: UIColor.gray800,
-                .kern: LabelConfiguration.titleSemi20.kern
+                .foregroundColor: UIColor.gray800
             ]
         )
 
@@ -130,8 +129,7 @@ private extension OnboardingThirdView {
                 string: accent,
                 attributes: [
                     .font: LabelConfiguration.titleSemi20.font,
-                    .foregroundColor: UIColor.accent,
-                    .kern: LabelConfiguration.titleSemi20.kern
+                    .foregroundColor: UIColor.accent
                 ]
             )
         )
@@ -144,8 +142,7 @@ private extension OnboardingThirdView {
             string: text,
             attributes: [
                 .font: LabelConfiguration.body14.font,
-                .foregroundColor: UIColor.gray300,
-                .kern: LabelConfiguration.body14.kern
+                .foregroundColor: UIColor.gray300
             ]
         )
     }

--- a/JaengYeo/JaengYeo/View/OnBorading/OnboardingViewController.swift
+++ b/JaengYeo/JaengYeo/View/OnBorading/OnboardingViewController.swift
@@ -23,6 +23,7 @@ final class OnboardingViewController: BaseViewController {
     private let scrollView = UIScrollView().then {
         $0.backgroundColor = .white
         $0.isPagingEnabled = true
+        $0.isDirectionalLockEnabled = true
         $0.showsHorizontalScrollIndicator = false
         $0.contentInsetAdjustmentBehavior = .never
     }
@@ -133,9 +134,10 @@ private extension OnboardingViewController {
         }
 
         makeStepViews().forEach { stepView in
-            contentStackView.addArrangedSubview(stepView)
+            let pageScrollView = makePageScrollView(stepView: stepView)
+            contentStackView.addArrangedSubview(pageScrollView)
 
-            stepView.snp.makeConstraints {
+            pageScrollView.snp.makeConstraints {
                 $0.width.equalTo(scrollView.frameLayoutGuide)
             }
         }
@@ -144,6 +146,35 @@ private extension OnboardingViewController {
 
 //MARK: - Data
 private extension OnboardingViewController {
+    func makePageScrollView(stepView: UIView) -> UIScrollView {
+        let pageScrollView = UIScrollView().then {
+            $0.backgroundColor = .white
+            $0.alwaysBounceVertical = true
+            $0.showsVerticalScrollIndicator = false
+            $0.contentInsetAdjustmentBehavior = .never
+            $0.isDirectionalLockEnabled = true
+        }
+
+        let contentView = UIView().then {
+            $0.backgroundColor = .white
+        }
+
+        pageScrollView.addSubview(contentView)
+        contentView.addSubview(stepView)
+
+        contentView.snp.makeConstraints {
+            $0.edges.equalTo(pageScrollView.contentLayoutGuide)
+            $0.width.equalTo(pageScrollView.frameLayoutGuide)
+        }
+
+        stepView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+        }
+
+        return pageScrollView
+    }
+
     func makeStepViews() -> [UIView] {
         [
             OnboardingFirstView(),

--- a/JaengYeo/JaengYeo/View/Register/RegisterDetailView.swift
+++ b/JaengYeo/JaengYeo/View/Register/RegisterDetailView.swift
@@ -25,7 +25,7 @@ final class RegisterDetailView: UIView {
         $0.font = LabelConfiguration.titleSemi16.font
         $0.textColor = .gray800
         $0.attributedPlaceholder = NSAttributedString(
-            string: "상품명을 입력해주세요.",
+            string: "상품명을 입력해주세요. (최대 20자)",
             attributes: [.foregroundColor: UIColor.gray300, .font: LabelConfiguration.body14.font]
         )
     }
@@ -35,7 +35,7 @@ final class RegisterDetailView: UIView {
         $0.textColor = .gray800
         $0.keyboardType = .numberPad
         $0.attributedPlaceholder = NSAttributedString(
-            string: "수량을 입력해주세요.",
+            string: "수량을 입력해주세요. (최대 999)",
             attributes: [.foregroundColor: UIColor.gray300, .font: LabelConfiguration.body14.font]
         )
     }
@@ -130,7 +130,7 @@ final class RegisterDetailView: UIView {
         $0.font = LabelConfiguration.titleSemi16.font
         $0.textColor = .gray800
         $0.attributedPlaceholder = NSAttributedString(
-            string: "유의사항 / 취급 주의사항을 입력해주세요.",
+            string: "유의사항 / 취급 주의사항을 입력해주세요. (최대 100자)",
             attributes: [.foregroundColor: UIColor.gray300, .font: LabelConfiguration.body14.font]
         )
     }
@@ -139,7 +139,7 @@ final class RegisterDetailView: UIView {
         $0.font = LabelConfiguration.titleSemi16.font
         $0.textColor = .gray800
         $0.attributedPlaceholder = NSAttributedString(
-            string: "구매하신 제품의 브랜드를 입력해주세요.",
+            string: "구매하신 제품의 브랜드를 입력해주세요. (최대 20자)",
             attributes: [.foregroundColor: UIColor.gray300, .font: LabelConfiguration.body14.font]
         )
     }
@@ -165,7 +165,7 @@ final class RegisterDetailView: UIView {
         $0.font = LabelConfiguration.titleSemi16.font
         $0.textColor = .gray800
         $0.attributedPlaceholder = NSAttributedString(
-            string: "자유롭게 메모해주세요.",
+            string: "자유롭게 메모해주세요. (최대 100자)",
             attributes: [.foregroundColor: UIColor.gray300, .font: LabelConfiguration.body14.font]
         )
     }

--- a/JaengYeo/JaengYeo/View/Register/RegisterDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Register/RegisterDetailViewController.swift
@@ -21,6 +21,15 @@ protocol RegisterDetailViewControllerDelegate: AnyObject {
 
 final class RegisterDetailViewController: BaseViewController {
 
+    //MARK: - Input Limit
+    private enum InputLimit {
+        static let productName = 20
+        static let brand = 20
+        static let caution = 100
+        static let memo = 100
+        static let quantity = 999
+    }
+
     override var handlesKeyboardInset: Bool { false }
 
     weak var delegate: RegisterDetailViewControllerDelegate?
@@ -73,11 +82,20 @@ final class RegisterDetailViewController: BaseViewController {
         configNavigationBar()
         restoreFields()
         configPhotoButton()
+        configureInputValidation()
         bind()
     }
 }
 
 extension RegisterDetailViewController {
+    private func configureInputValidation() {
+        mainView.nameField.delegate = self
+        mainView.quantityField.delegate = self
+        mainView.cautionField.delegate = self
+        mainView.brandField.delegate = self
+        mainView.memoField.delegate = self
+    }
+
     private func configNavigationBar() {
         navigationItem.title = viewModel.item.name ?? "상세 입력"
         let appearance = UINavigationBarAppearance()
@@ -108,6 +126,111 @@ extension RegisterDetailViewController {
             mainView.photoButton.clipsToBounds = true
             mainView.photoButton.layer.cornerRadius = 8
         }
+    }
+}
+
+//MARK: - UITextFieldDelegate
+extension RegisterDetailViewController: UITextFieldDelegate {
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        if textField == mainView.quantityField {
+            return validateNumericInput(
+                currentText: textField.text,
+                range: range,
+                replacementString: string
+            )
+        }
+
+        if textField == mainView.nameField {
+            return validateTextLength(
+                currentText: textField.text,
+                range: range,
+                replacementString: string,
+                maxLength: InputLimit.productName
+            )
+        }
+
+        if textField == mainView.brandField {
+            return validateTextLength(
+                currentText: textField.text,
+                range: range,
+                replacementString: string,
+                maxLength: InputLimit.brand
+            )
+        }
+
+        if textField == mainView.cautionField {
+            return validateTextLength(
+                currentText: textField.text,
+                range: range,
+                replacementString: string,
+                maxLength: InputLimit.caution
+            )
+        }
+
+        if textField == mainView.memoField {
+            return validateTextLength(
+                currentText: textField.text,
+                range: range,
+                replacementString: string,
+                maxLength: InputLimit.memo
+            )
+        }
+
+        return true
+    }
+
+    private func validateTextLength(
+        currentText: String?,
+        range: NSRange,
+        replacementString string: String,
+        maxLength: Int
+    ) -> Bool {
+        guard let currentText else { return string.count <= maxLength }
+
+        let updatedText = (currentText as NSString).replacingCharacters(
+            in: range,
+            with: string
+        )
+        return updatedText.count <= maxLength
+    }
+
+    private func validateNumericInput(
+        currentText: String?,
+        range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        if string.isEmpty {
+            return true
+        }
+
+        // Prevent pasting into numeric-only input.
+        if string.count > 1 {
+            return false
+        }
+
+        let allowedCharacterSet = CharacterSet.decimalDigits
+        guard string.rangeOfCharacter(from: allowedCharacterSet.inverted) == nil else {
+            return false
+        }
+
+        guard let currentText else { return true }
+        let updatedText = (currentText as NSString).replacingCharacters(
+            in: range,
+            with: string
+        )
+        guard updatedText.rangeOfCharacter(from: allowedCharacterSet.inverted) == nil else {
+            return false
+        }
+
+        guard let value = Int(updatedText) else {
+            return false
+        }
+
+        return value <= InputLimit.quantity
     }
 }
 

--- a/JaengYeo/JaengYeo/View/Stock/CategoryEditDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategoryEditDetailViewController.swift
@@ -13,6 +13,11 @@ import RxSwift
 
 final class CategoryEditDetailViewController: BaseViewController {
 
+    //MARK: - Input Limit
+    private enum InputLimit {
+        static let categoryName = 10
+    }
+
     //MARK: - Properties
     /// 편집 모드
     private let mode: CategoryEditMode
@@ -42,7 +47,7 @@ final class CategoryEditDetailViewController: BaseViewController {
     private let nameTextField = UITextField().then {
         $0.font = LabelConfiguration.bodyMedium14.font
         $0.textColor = .gray800
-        $0.placeholder = "분류 이름을 입력해주세요"
+        $0.placeholder = "분류 이름을 입력해주세요. (최대 10자)"
     }
 
     /// 입력 필드 하단 라인
@@ -83,6 +88,7 @@ final class CategoryEditDetailViewController: BaseViewController {
         configureNavigationBar()
         configureUI()
         configureData()
+        configureInputValidation()
         configureKeyboardDismiss()
         bind()
     }
@@ -90,6 +96,11 @@ final class CategoryEditDetailViewController: BaseViewController {
 
 //MARK: - Bind
 private extension CategoryEditDetailViewController {
+    /// 입력 제한 설정
+    func configureInputValidation() {
+        nameTextField.delegate = self
+    }
+
     func bind() {
         let confirmRelay = PublishRelay<Void>()
         let deleteConfirmedRelay = PublishRelay<Void>()
@@ -161,6 +172,25 @@ private extension CategoryEditDetailViewController {
                 self?.presentCategoryIcons()
             })
             .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - UITextFieldDelegate
+extension CategoryEditDetailViewController: UITextFieldDelegate {
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        guard textField == nameTextField else { return true }
+
+        let currentText = textField.text ?? ""
+        let updatedText = (currentText as NSString).replacingCharacters(
+            in: range,
+            with: string
+        )
+
+        return updatedText.count <= InputLimit.categoryName
     }
 }
 

--- a/JaengYeo/JaengYeo/View/Stock/CategoryEditViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategoryEditViewController.swift
@@ -115,11 +115,6 @@ private extension CategoryEditViewController {
             .asObservable()
             .filter { $0 >= 0 }
             .distinctUntilChanged()
-            .throttle(
-                .milliseconds(250),
-                latest: false,
-                scheduler: MainScheduler.instance
-            )
 
         let input = CategoryEditViewModel.Input(
             viewDidLoad: Observable.just(()),

--- a/JaengYeo/JaengYeo/View/Stock/CategoryEditViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategoryEditViewController.swift
@@ -111,6 +111,16 @@ final class CategoryEditViewController: BaseViewController {
 //MARK: - Bind
 private extension CategoryEditViewController {
     func bind() {
+        let mainCategorySelected = mainCategorySegment.rx.selectedSegmentIndex
+            .asObservable()
+            .filter { $0 >= 0 }
+            .distinctUntilChanged()
+            .throttle(
+                .milliseconds(250),
+                latest: false,
+                scheduler: MainScheduler.instance
+            )
+
         let input = CategoryEditViewModel.Input(
             viewDidLoad: Observable.just(()),
             viewWillAppear: viewWillAppearRelay
@@ -118,9 +128,7 @@ private extension CategoryEditViewController {
                     self?.mainCategorySegment.selectedSegmentIndex ?? 0
                 }
                 .filter { $0 >= 0 },
-            mainCategorySelected: mainCategorySegment.rx.selectedSegmentIndex
-                .asObservable()
-                .filter { $0 >= 0 },
+            mainCategorySelected: mainCategorySelected,
             deleteItemSelected: deleteItemSelectedRelay.asObservable()
         )
 

--- a/JaengYeo/JaengYeo/View/Stock/CategorySelectionView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategorySelectionView.swift
@@ -63,7 +63,6 @@ final class CategorySelectionView: UIView {
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attributes in
             var output = attributes
             output.font = ButtonTitleConfiguration.resetTitle.font
-            output.kern = ButtonTitleConfiguration.resetTitle.kern
             return output
         }
         $0.configuration = config

--- a/JaengYeo/JaengYeo/View/Stock/CategorySelectionView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategorySelectionView.swift
@@ -53,13 +53,20 @@ final class CategorySelectionView: UIView {
     }
 
     /// 초기화 버튼
-    let resetButton = StyledButton(
-        title: "초기화",
-        titleConfiguration: .resetTitle,
-        appearanceConfiguration: .textAppearance
-    ).then {
-        $0.setImage(UIImage(systemName: "arrow.counterclockwise"), for: .normal)
-        $0.tintColor = .gray300
+    let resetButton = UIButton().then {
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "arrow.counterclockwise")
+        config.title = "초기화"
+        config.imagePadding = 4
+        config.baseForegroundColor = .gray300
+        config.contentInsets = .zero
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attributes in
+            var output = attributes
+            output.font = ButtonTitleConfiguration.resetTitle.font
+            output.kern = ButtonTitleConfiguration.resetTitle.kern
+            return output
+        }
+        $0.configuration = config
     }
 
     /// 필터 적용 버튼

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
@@ -28,18 +28,24 @@ final class ProductDetailView: UIView {
         $0.text = "상품명"
         $0.numberOfLines = 1
         $0.lineBreakMode = .byTruncatingTail
+        $0.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        $0.setContentHuggingPriority(.defaultLow, for: .horizontal)
     }
     
     let countLabel = StyledLabel(
         config: LabelConfiguration.titleBold28.updatingColor(color: .accent)
     ).then {
         $0.text = "00"
+        $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+        $0.setContentHuggingPriority(.required, for: .horizontal)
     }
     
     let countTitleLabel = StyledLabel(
         config: LabelConfiguration.titleSemi20.updatingColor(color: .gray500))
         .then {
             $0.text = "개"
+            $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+            $0.setContentHuggingPriority(.required, for: .horizontal)
         }
 
     let scrollView = UIScrollView().then {
@@ -235,7 +241,7 @@ extension ProductDetailView {
         productNameLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalTo(productImageView.snp.trailing).offset(8)
-            $0.trailing.lessThanOrEqualTo(countLabel.snp.leading).offset(-8)
+            $0.trailing.lessThanOrEqualTo(countLabel.snp.leading).offset(-8).priority(999)
         }
         
         countTitleLabel.snp.makeConstraints {

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailView.swift
@@ -26,6 +26,8 @@ final class ProductDetailView: UIView {
     
     let productNameLabel = StyledLabel(config: .titleBold24).then {
         $0.text = "상품명"
+        $0.numberOfLines = 1
+        $0.lineBreakMode = .byTruncatingTail
     }
     
     let countLabel = StyledLabel(
@@ -233,6 +235,7 @@ extension ProductDetailView {
         productNameLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalTo(productImageView.snp.trailing).offset(8)
+            $0.trailing.lessThanOrEqualTo(countLabel.snp.leading).offset(-8)
         }
         
         countTitleLabel.snp.makeConstraints {

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
@@ -26,6 +26,7 @@ final class ProductDetailViewController: BaseViewController {
     let viewModel: ProductDetailViewModel
 
     let disposeBag = DisposeBag()
+    private let viewWillAppearRelay = PublishRelay<Void>()
 
     let productDetailView = ProductDetailView()
 
@@ -44,6 +45,11 @@ final class ProductDetailViewController: BaseViewController {
         super.viewDidLoad()
         configureUI()
         bind()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewWillAppearRelay.accept(())
     }
 }
 
@@ -69,6 +75,7 @@ extension ProductDetailViewController {
         
         let input = ProductDetailViewModel.Input(
             viewDidLoad: Observable.just(()),
+            viewWillAppear: viewWillAppearRelay.asObservable(),
             modifyTapped: productDetailView.modifyButton.rx.tap.asObservable(),
             deleteTapped: deleteTap
         )

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
@@ -79,7 +79,7 @@ extension ProductDetailViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] displayModel in
                 guard let self else { return }
-                self.title = displayModel.productName
+                self.title = "상세 정보"
                 self.productDetailView.updateUI(displayModel: displayModel)
             })
             .disposed(by: disposeBag)

--- a/JaengYeo/JaengYeo/View/Stock/ProductGroupListViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductGroupListViewController.swift
@@ -157,15 +157,15 @@ private extension ProductGroupListViewController {
         
         return AlertController.rx.alert(
             on: self,
-            image: UIImage(named: "alertRed") ?? UIImage(),
-            title: "재고 차감",
-            message: "재고가 0이 되면 상품은 삭제됩니다.\n삭제하시겠습니까?",
+            image: UIImage(named: "alertBlue") ?? UIImage(),
+            title: "재고가 0개 입니다.",
+            message: "확인을 누르시면 해당 물품이 삭제됩니다.",
             actions: [
                 .cancel("취소"),
-                .destructive("삭제")
+                .default("확인")
             ]
         )
-        .filter { $0.title == "삭제" }
+        .filter { $0.title == "확인" }
         .map { _ in item }
         .asObservable()
     }

--- a/JaengYeo/JaengYeo/View/Stock/ProductGroupListViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductGroupListViewController.swift
@@ -113,6 +113,8 @@ private extension ProductGroupListViewController {
 private extension ProductGroupListViewController {
     /// 상품 수량 증가
     func increaseItem(_ item: ProductCellItem) {
+        guard item.product.quantity < Product.maxQuantity else { return }
+
         let updatedProduct = item.product.increasedQuantity()
         onIncrease?(updatedProduct)
         updateItem(productID: item.product.id, product: updatedProduct)

--- a/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
@@ -20,6 +20,11 @@ protocol StockSearchViewControllerDelegate: AnyObject {
 
 final class StockSearchViewController: BaseViewController {
 
+    //MARK: - Input Limit
+    private enum InputLimit {
+        static let searchKeyword = 20
+    }
+
     //MARK: - Enum
     private enum Section {
         case recentSearch
@@ -60,7 +65,7 @@ final class StockSearchViewController: BaseViewController {
 
     /// 검색바
     private let searchBar = UISearchBar().then {
-        $0.placeholder = "키워드 입력"
+        $0.placeholder = "키워드 입력 (최대 20자)"
         $0.searchBarStyle = .minimal
         $0.returnKeyType = .search
         $0.backgroundImage = UIImage()
@@ -99,6 +104,7 @@ final class StockSearchViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        configureInputValidation()
         bind()
     }
 
@@ -120,6 +126,10 @@ final class StockSearchViewController: BaseViewController {
 
 //MARK: - Binding
 private extension StockSearchViewController {
+    func configureInputValidation() {
+        searchBar.delegate = self
+    }
+
     func bind() {
         
         let searchText = searchBar.rx.text.orEmpty
@@ -177,6 +187,23 @@ private extension StockSearchViewController {
                 self?.selectProduct(item)
             })
             .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - UISearchBarDelegate
+extension StockSearchViewController: UISearchBarDelegate {
+    func searchBar(
+        _ searchBar: UISearchBar,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
+    ) -> Bool {
+        let currentText = searchBar.text ?? ""
+        let updatedText = (currentText as NSString).replacingCharacters(
+            in: range,
+            with: text
+        )
+
+        return updatedText.count <= InputLimit.searchKeyword
     }
 }
 
@@ -336,15 +363,15 @@ private extension StockSearchViewController {
 
         return AlertController.rx.alert(
             on: self,
-            image: UIImage(named: "alertRed") ?? UIImage(),
-            title: "재고 차감",
-            message: "재고가 0이 되면 상품은 삭제됩니다.\n삭제하시겠습니까?",
+            image: UIImage(named: "alertBlue") ?? UIImage(),
+            title: "재고가 0개 입니다.",
+            message: "확인을 누르시면 해당 물품이 삭제됩니다.",
             actions: [
                 .cancel("취소"),
-                .destructive("삭제")
+                .default("확인")
             ]
         )
-        .filter { $0.title == "삭제" }
+        .filter { $0.title == "확인" }
         .map { _ in .delete([item.product.id]) }
         .asObservable()
     }

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -97,6 +97,16 @@ private extension StockViewController {
         let subCategoryAppliedRelay = PublishRelay<[String]>()
         /// 상품 정렬 선택
         let sortOptionSelectedRelay = PublishRelay<ProductSortOption>()
+        /// 메인 카테고리 선택
+        let mainCategorySelected = mainCategorySegment.rx.selectedSegmentIndex
+            .asObservable()
+            .filter { $0 >= 0 }
+            .distinctUntilChanged()
+            .throttle(
+                .milliseconds(250),
+                latest: false,
+                scheduler: MainScheduler.instance
+            )
         
         productCollectionView.configureSortMenu { sortOption in
             sortOptionSelectedRelay.accept(sortOption)
@@ -146,9 +156,7 @@ private extension StockViewController {
         let input = StockViewModel.Input(
             viewDidLoad: Observable.just(()),
             viewWillAppear: viewWillAppearRelay.asObservable(),
-            mainCategorySelected: mainCategorySegment.rx.selectedSegmentIndex
-                .asObservable()
-                .filter { $0 >= 0 },
+            mainCategorySelected: mainCategorySelected,
             midCategoryTapped: categoryFilterView.midCategoryButton.rx.tap.asObservable(),
             subCategoryTapped: categoryFilterView.subCategoryButton.rx.tap.asObservable(),
             midCategoryApplied: midCategoryAppliedRelay.asObservable(),
@@ -334,15 +342,15 @@ private extension StockViewController {
         
         return AlertController.rx.alert(
             on: self,
-            image: UIImage(named: "alertRed") ?? UIImage(),
-            title: "재고 차감",
-            message: "재고가 0이 되면 상품은 삭제됩니다.\n삭제하시겠습니까?",
+            image: UIImage(named: "alertBlue") ?? UIImage(),
+            title: "재고가 0개 입니다.",
+            message: "확인을 누르시면 해당 물품이 삭제됩니다.",
             actions: [
                 .cancel("취소"),
-                .destructive("삭제")
+                .default("확인")
             ]
         )
-        .filter { $0.title == "삭제" }
+        .filter { $0.title == "확인" }
         .map { _ in .delete([targetProduct.id]) }
         .asObservable()
     }

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -102,11 +102,6 @@ private extension StockViewController {
             .asObservable()
             .filter { $0 >= 0 }
             .distinctUntilChanged()
-            .throttle(
-                .milliseconds(250),
-                latest: false,
-                scheduler: MainScheduler.instance
-            )
         
         productCollectionView.configureSortMenu { sortOption in
             sortOptionSelectedRelay.accept(sortOption)

--- a/JaengYeo/JaengYeo/ViewModel/HomeViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/HomeViewModel.swift
@@ -232,6 +232,7 @@ private extension HomeViewModel {
     /// 최근 등록 상품 재고 1개 증가
     func increaseRecentItemQuantity(productID: UUID) {
         guard let product = try? coreDataManager.fetchProduct(of: productID) else { return }
+        guard product.quantity < Product.maxQuantity else { return }
 
         do {
             try coreDataManager.updateProduct(

--- a/JaengYeo/JaengYeo/ViewModel/Stock/ProductDetailViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/ProductDetailViewModel.swift
@@ -50,6 +50,7 @@ final class ProductDetailViewModel: NSObject, ViewModelProtocol {
     
     struct Input {
         let viewDidLoad: Observable<Void>
+        let viewWillAppear: Observable<Void>
         let modifyTapped: Observable<Void>
         let deleteTapped: Observable<Void>
     }
@@ -75,7 +76,7 @@ final class ProductDetailViewModel: NSObject, ViewModelProtocol {
         }
         .compactMap { $0 }
         
-        input.viewDidLoad
+        Observable.merge(input.viewDidLoad, input.viewWillAppear)
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
                 self.bindProduct()

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
@@ -108,19 +108,25 @@ final class StockSearchViewModel: NSObject, ViewModelProtocol {
 
         input.productQuantityIncreased
             .subscribe(onNext: { [weak self] product in
-                self?.increaseProductQuantity(product)
+                guard let self else { return }
+                self.increaseProductQuantity(product)
+                self.refreshProducts()
             })
             .disposed(by: disposeBag)
 
         input.productQuantityDecreased
             .subscribe(onNext: { [weak self] product in
-                self?.decreaseProductQuantity(product)
+                guard let self else { return }
+                self.decreaseProductQuantity(product)
+                self.refreshProducts()
             })
             .disposed(by: disposeBag)
 
         input.productDeleted
             .subscribe(onNext: { [weak self] productIDs in
-                self?.deleteProducts(productIDs)
+                guard let self else { return }
+                self.deleteProducts(productIDs)
+                self.refreshProducts()
             })
             .disposed(by: disposeBag)
 
@@ -220,6 +226,11 @@ private extension StockSearchViewModel {
         let searches = (try? coreDataManager.fetchRecentSearches(limit: 10)) ?? []
         recentSearchesRelay.accept(searches)
     }
+
+    /// 상품 목록 재조회
+    func refreshProducts() {
+        bindProducts()
+    }
 }
 
 //MARK: - Update Products
@@ -314,6 +325,8 @@ private extension StockSearchViewModel {
 private extension StockSearchViewModel {
     /// 상품 재고 1개 증가
     func increaseProductQuantity(_ product: Product) {
+        guard product.quantity < Product.maxQuantity else { return }
+
         do {
             try coreDataManager.updateProduct(
                 product

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockViewModel.swift
@@ -685,6 +685,8 @@ private extension StockViewModel {
 private extension StockViewModel {
     /// 상품 재고 1개 증가
     func increaseProductQuantity(_ product: Product) {
+        guard product.quantity < Product.maxQuantity else { return }
+
         do {
             try coreDataManager.updateProduct(
                 product


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #

## 🛠 작업 내용 (What I did)
- 입력 필드 길이 제한과 숫자 입력 검증을 추가해 잘못된 입력을 방지했습니다.
- 세그먼트 전환 중복 갱신 이슈를 보완하고, 즉시 반응하도록 반응성을 다시 조정했습니다.
- 버튼 및 리스트 간격, 공통 텍스트 스타일을 정리해 UI 일관성을 맞췄습니다.
- 상품 상세 화면의 상단 타이틀 레이아웃과 네비게이션 제목을 수정했습니다.
- 상품 상세 화면 재진입 시 수정된 내용이 바로 반영되도록 갱신 흐름을 보강했습니다.
- 재고 수량 증가 최대값을 999로 제한했습니다.

## 💻 구현 상세 (Implementation Details)
- 상품명, 브랜드, 분류명, 메모, 유의사항, 검색어 길이 제한 적용
- 수량 필드 숫자만 입력 가능, 붙여넣기 차단, 최대값 999 제한 적용
- 세그먼트 선택 스트림에서 중복 이벤트 차단
- 세그먼트 전환 시 목록이 즉시 반영되도록 반응성 복구
- 버튼 및 리스트 간격, 정렬 UI 세부 조정
- LabelConfiguration, ButtonTitleConfiguration의 자간 설정 제거
- 상품 상세 상단에서 상품명과 수량 라벨이 겹치지 않도록 우선순위 및 제약 수정
- 상품 상세 네비게이션 타이틀을 상세 정보로 고정
- 상세 화면 viewWillAppear 기반 재조회 추가
- 재고/검색/홈/중복상품 모달의 수량 증가 로직에 999 상한 가드 추가
