### PR TITLE
Feat/account#140

### DIFF
--- a/JaengYeo/JaengYeo.xcodeproj/project.pbxproj
+++ b/JaengYeo/JaengYeo.xcodeproj/project.pbxproj
@@ -265,7 +265,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = JaengYeo/JaengYeo.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -286,7 +286,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.jaengyoeo.JaengYeo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = jaengyeoDevelopment;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = jaengyeoDistribution;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/JaengYeo/JaengYeo.xcodeproj/project.pbxproj
+++ b/JaengYeo/JaengYeo.xcodeproj/project.pbxproj
@@ -225,7 +225,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PFJA392RSN;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -267,7 +267,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = PFJA392RSN;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;

--- a/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
@@ -109,7 +109,7 @@ extension HomeCoordinator {
     
     private func pushMyPage() {
         let viewController = MyPageViewController(
-            viewModel: MyPageViewModel(authManager: authManager)
+            viewModel: MyPageViewModel(authManager: authManager, coreDataManager: coreDataManager)
         )
         viewController.delegate = self
         navigationController.pushViewController(viewController, animated: true)

--- a/JaengYeo/JaengYeo/Data/CoreData/CoreDataManager.swift
+++ b/JaengYeo/JaengYeo/Data/CoreData/CoreDataManager.swift
@@ -926,6 +926,27 @@ extension CoreDataManager {
         }
     }
     
+    func deleteAllUserData() throws {
+        let entityNames = [
+            ProductEntity.className,
+            MidCategoryEntity.className,
+            SubCategoryEntity.className,
+            RecentSearchEntity.className
+        ]
+        for name in entityNames {
+            let request = NSFetchRequest<NSFetchRequestResult>(entityName: name)
+            let batchDelete = NSBatchDeleteRequest(fetchRequest: request)
+            batchDelete.resultType = .resultTypeObjectIDs
+            let result = try context.execute(batchDelete) as? NSBatchDeleteResult
+            if let objectIDs = result?.result as? [NSManagedObjectID] {
+                NSManagedObjectContext.mergeChanges(
+                    fromRemoteContextSave: [NSDeletedObjectsKey: objectIDs],
+                    into: [context]
+                )
+            }
+        }
+    }
+
     // 최대 보관 개수 초과 시 오래된 항목 삭제용 -> 내부호출용으로 protocol 추상화 x
     private func trimRecentSearches(limit: Int) throws {
         let request = RecentSearchEntity.fetchRequest()

--- a/JaengYeo/JaengYeo/Data/CoreData/CoreDataManagerProtocol.swift
+++ b/JaengYeo/JaengYeo/Data/CoreData/CoreDataManagerProtocol.swift
@@ -74,4 +74,7 @@ protocol CoreDataManagerProtocol {
     func fetchRecentSearches(limit: Int) throws -> [RecentSearchPayload]
     func deleteRecentSearch(id: UUID) throws
     func deleteAllRecentSearches() throws
+
+    //MARK: - 계정 삭제
+    func deleteAllUserData() throws
 }

--- a/JaengYeo/JaengYeo/Data/CoreData/RecentSearchEntity+CoreDataClass.swift
+++ b/JaengYeo/JaengYeo/Data/CoreData/RecentSearchEntity+CoreDataClass.swift
@@ -13,5 +13,5 @@ public typealias RecentSearchEntityCoreDataClassSet = NSSet
 
 @objc(RecentSearchEntity)
 public class RecentSearchEntity: NSManagedObject {
-
+    static let className = "RecentSearchEntity"
 }

--- a/JaengYeo/JaengYeo/Network/AuthManager.swift
+++ b/JaengYeo/JaengYeo/Network/AuthManager.swift
@@ -46,4 +46,24 @@ final class AuthManager: AuthManagerProtocol {
         try await client.auth.signOut()
     }
     
+    func deleteAccount() async throws {
+        let accessToken = try await client.auth.session.accessToken
+        
+        guard let url = URL(string: "\(Constants.Supabase.url)/functions/v1/delete-account") else {
+            throw NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "잘못된 URL"])
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        
+        let (_, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "계정 삭제 실패"])
+        }
+        try await client.auth.signOut()
+    }
+    
 }

--- a/JaengYeo/JaengYeo/Network/AuthManager.swift
+++ b/JaengYeo/JaengYeo/Network/AuthManager.swift
@@ -46,9 +46,9 @@ final class AuthManager: AuthManagerProtocol {
         try await client.auth.signOut()
     }
     
-    func deleteAccount() async throws {
+    func deleteAccount(authorizationCode: String) async throws {
         let accessToken = try await client.auth.session.accessToken
-        
+
         guard let url = URL(string: "\(Constants.Supabase.url)/functions/v1/delete-account") else {
             throw NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "잘못된 URL"])
         }
@@ -56,9 +56,12 @@ final class AuthManager: AuthManagerProtocol {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        
+        request.httpBody = try JSONSerialization.data(
+            withJSONObject: ["authorizationCode": authorizationCode]
+        )
+
         let (_, response) = try await URLSession.shared.data(for: request)
-        
+
         guard let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200 else {
             throw NSError(domain: "AuthManager", code: -1, userInfo: [NSLocalizedDescriptionKey: "계정 삭제 실패"])

--- a/JaengYeo/JaengYeo/Network/AuthManagerProtocol.swift
+++ b/JaengYeo/JaengYeo/Network/AuthManagerProtocol.swift
@@ -13,4 +13,5 @@ protocol AuthManagerProtocol {
     func restoreSession() async -> Bool
     func signInWithApple(idToken: String, nonce: String) async throws
     func signOut() async throws
+    func deleteAccount() async throws
 }

--- a/JaengYeo/JaengYeo/Network/AuthManagerProtocol.swift
+++ b/JaengYeo/JaengYeo/Network/AuthManagerProtocol.swift
@@ -13,5 +13,5 @@ protocol AuthManagerProtocol {
     func restoreSession() async -> Bool
     func signInWithApple(idToken: String, nonce: String) async throws
     func signOut() async throws
-    func deleteAccount() async throws
+    func deleteAccount(authorizationCode: String) async throws
 }

--- a/JaengYeo/JaengYeo/View/MyPage/MyPageView.swift
+++ b/JaengYeo/JaengYeo/View/MyPage/MyPageView.swift
@@ -74,7 +74,7 @@ extension MyPageView {
             cell.updateUI(
                 title: item.title,
                 showsChevron: item.showsArrow,
-                titleColor: item.menu == .logout ? .primaryRed : .gray800
+                titleColor: (item.menu == .logout || item.menu == .deleteAccount) ? .primaryRed : .gray800
             )
         }
 

--- a/JaengYeo/JaengYeo/View/MyPage/MyPageViewController.swift
+++ b/JaengYeo/JaengYeo/View/MyPage/MyPageViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Codex on 4/20/26.
 //
 
+import AuthenticationServices
 import MessageUI
 import RxCocoa
 import RxSwift
@@ -29,7 +30,7 @@ final class MyPageViewController: BaseViewController {
     
     weak var delegate: MyPageViewControllerDelegate?
     private let logoutConfirmRelay = PublishRelay<Void>()
-    private let deleteAccountConfirmRelay = PublishRelay<Void>()
+    private let deleteAccountConfirmRelay = PublishRelay<String>()
 
     //MARK: - Init
     init(viewModel: MyPageViewModel) {
@@ -249,9 +250,43 @@ extension MyPageViewController {
         )
         .subscribe(onNext: { [weak self] action in
             if action.style == .destructive {
-                self?.deleteAccountConfirmRelay.accept(())
+                self?.requestAppleAuthorizationCode()
             }
         })
         .disposed(by: disposeBag)
+    }
+
+    private func requestAppleAuthorizationCode() {
+        let provider = ASAuthorizationAppleIDProvider()
+        let request = provider.createRequest()
+        request.requestedScopes = []
+
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        controller.performRequests()
+    }
+}
+
+extension MyPageViewController: ASAuthorizationControllerDelegate {
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let codeData = credential.authorizationCode,
+              let code = String(data: codeData, encoding: .utf8) else { return }
+        deleteAccountConfirmRelay.accept(code)
+    }
+
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: any Error
+    ) {}
+}
+
+extension MyPageViewController: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        view.window!
     }
 }

--- a/JaengYeo/JaengYeo/View/MyPage/MyPageViewController.swift
+++ b/JaengYeo/JaengYeo/View/MyPage/MyPageViewController.swift
@@ -29,6 +29,7 @@ final class MyPageViewController: BaseViewController {
     
     weak var delegate: MyPageViewControllerDelegate?
     private let logoutConfirmRelay = PublishRelay<Void>()
+    private let deleteAccountConfirmRelay = PublishRelay<Void>()
 
     //MARK: - Init
     init(viewModel: MyPageViewModel) {
@@ -58,7 +59,8 @@ extension MyPageViewController {
         let input = MyPageViewModel.Input(
             viewDidLoad: Observable.just(()),
             itemSelected: myPageView.itemSelected,
-            logoutConfirmed: logoutConfirmRelay.asObservable()
+            logoutConfirmed: logoutConfirmRelay.asObservable(),
+            deleteAccountConfirmed: deleteAccountConfirmRelay.asObservable()
         )
 
         let output = viewModel.transform(input)
@@ -112,6 +114,18 @@ extension MyPageViewController {
             .disposed(by: disposeBag)
         
         output.logoutCompleted
+            .bind(onNext: { [weak self] in
+                self?.delegate?.didLogout()
+            })
+            .disposed(by: disposeBag)
+
+        output.showDeleteAccountConfirm
+            .bind(onNext: { [weak self] in
+                self?.showDeleteAccountAlert()
+            })
+            .disposed(by: disposeBag)
+
+        output.deleteAccountCompleted
             .bind(onNext: { [weak self] in
                 self?.delegate?.didLogout()
             })
@@ -220,6 +234,22 @@ extension MyPageViewController {
         .subscribe(onNext: { [weak self] action in
             if action.style == .destructive {
                 self?.logoutConfirmRelay.accept(())
+            }
+        })
+        .disposed(by: disposeBag)
+    }
+
+    private func showDeleteAccountAlert() {
+        AlertController.rx.alert(
+            on: self,
+            image: UIImage(named: "alertRed") ?? UIImage(),
+            title: "회원 탈퇴",
+            message: "탈퇴 시 모든 데이터가 영구 삭제되며\n복구할 수 없습니다.",
+            actions: [.cancel("취소"), .destructive("탈퇴")]
+        )
+        .subscribe(onNext: { [weak self] action in
+            if action.style == .destructive {
+                self?.deleteAccountConfirmRelay.accept(())
             }
         })
         .disposed(by: disposeBag)

--- a/JaengYeo/JaengYeo/ViewModel/MyPage/MyPageViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/MyPage/MyPageViewModel.swift
@@ -139,7 +139,7 @@ final class MyPageViewModel: ViewModelProtocol {
         let itemSelected: Observable<MyPageItem>
         
         let logoutConfirmed: Observable<Void>
-        let deleteAccountConfirmed: Observable<Void>
+        let deleteAccountConfirmed: Observable<String>
     }
 
     struct Output {
@@ -234,12 +234,12 @@ final class MyPageViewModel: ViewModelProtocol {
             .disposed(by: disposeBag)
 
         input.deleteAccountConfirmed
-            .flatMapLatest { [weak self] _ -> Observable<Void> in
+            .flatMapLatest { [weak self] code -> Observable<Void> in
                 guard let self else { return .empty() }
                 return Observable.create { observer in
                     Task {
                         do {
-                            try await self.authManager.deleteAccount()
+                            try await self.authManager.deleteAccount(authorizationCode: code)
                             try? self.coreDataManager.deleteAllUserData()
                             await MainActor.run {
                                 observer.onNext(())

--- a/JaengYeo/JaengYeo/ViewModel/MyPage/MyPageViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/MyPage/MyPageViewModel.swift
@@ -26,6 +26,7 @@ enum MyPageMenu: CaseIterable {
     case appVersion
     case iconCopyright
     case logout
+    case deleteAccount
 
     /// 섹션 타이틀
     var section: MyPageMenuSection {
@@ -35,6 +36,8 @@ enum MyPageMenu: CaseIterable {
         case .feedback, .appVersion, .iconCopyright:
             return .appInfo
         case .logout:
+            return .account
+        case .deleteAccount:
             return .account
         }
     }
@@ -56,13 +59,15 @@ enum MyPageMenu: CaseIterable {
             return "아이콘 저작권 : icons8"
         case .logout:
             return "로그아웃"
+        case .deleteAccount:
+            return "회원 탈퇴"
         }
     }
 
     /// 화살표 표시 여부
     var showsArrow: Bool {
         switch self {
-        case .logout:
+        case .logout, .deleteAccount:
             return false
         default:
             return true
@@ -120,9 +125,11 @@ final class MyPageViewModel: ViewModelProtocol {
     private let disposeBag = DisposeBag()
     private let supportEmail = "jaengyeo09@gmail.com"
     private let authManager: AuthManagerProtocol
-    
-    init(authManager: AuthManagerProtocol) {
+    private let coreDataManager: CoreDataManagerProtocol
+
+    init(authManager: AuthManagerProtocol, coreDataManager: CoreDataManagerProtocol) {
         self.authManager = authManager
+        self.coreDataManager = coreDataManager
     }
 
     struct Input {
@@ -132,6 +139,7 @@ final class MyPageViewModel: ViewModelProtocol {
         let itemSelected: Observable<MyPageItem>
         
         let logoutConfirmed: Observable<Void>
+        let deleteAccountConfirmed: Observable<Void>
     }
 
     struct Output {
@@ -150,6 +158,8 @@ final class MyPageViewModel: ViewModelProtocol {
         
         let showLogoutConfirm: Observable<Void>
         let logoutCompleted: Observable<Void>
+        let showDeleteAccountConfirm: Observable<Void>
+        let deleteAccountCompleted: Observable<Void>
     }
 
     func transform(_ input: Input) -> Output {
@@ -160,6 +170,8 @@ final class MyPageViewModel: ViewModelProtocol {
         let openExternalURLRelay = PublishRelay<URL>()
         let showLogoutConfirmRelay = PublishRelay<Void>()
         let logoutCompletedRelay = PublishRelay<Void>()
+        let showDeleteAccountConfirmRelay = PublishRelay<Void>()
+        let deleteAccountCompletedRelay = PublishRelay<Void>()
 
         let sections = input.viewDidLoad
             .map { [weak self] in
@@ -194,7 +206,8 @@ final class MyPageViewModel: ViewModelProtocol {
                     }
                 case .logout:
                     showLogoutConfirmRelay.accept(())
-                
+                case .deleteAccount:
+                    showDeleteAccountConfirmRelay.accept(())
                 }
             })
             .disposed(by: disposeBag)
@@ -220,6 +233,28 @@ final class MyPageViewModel: ViewModelProtocol {
             .bind(to: logoutCompletedRelay)
             .disposed(by: disposeBag)
 
+        input.deleteAccountConfirmed
+            .flatMapLatest { [weak self] _ -> Observable<Void> in
+                guard let self else { return .empty() }
+                return Observable.create { observer in
+                    Task {
+                        do {
+                            try await self.authManager.deleteAccount()
+                            try? self.coreDataManager.deleteAllUserData()
+                            await MainActor.run {
+                                observer.onNext(())
+                                observer.onCompleted()
+                            }
+                        } catch {
+                            observer.onCompleted()
+                        }
+                    }
+                    return Disposables.create()
+                }
+            }
+            .bind(to: deleteAccountCompletedRelay)
+            .disposed(by: disposeBag)
+
         return Output(
             sections: sections,
             showGuide: showGuideRelay.asObservable(),
@@ -228,7 +263,9 @@ final class MyPageViewModel: ViewModelProtocol {
             composeFeedbackMail: composeFeedbackMailRelay.asObservable(),
             openExternalURL: openExternalURLRelay.asObservable(),
             showLogoutConfirm: showLogoutConfirmRelay.asObservable(),
-            logoutCompleted: logoutCompletedRelay.asObservable()
+            logoutCompleted: logoutCompletedRelay.asObservable(),
+            showDeleteAccountConfirm: showDeleteAccountConfirmRelay.asObservable(),
+            deleteAccountCompleted: deleteAccountCompletedRelay.asObservable()
         )
     }
 }

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -3,6 +3,99 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const APPLE_CLIENT_ID = Deno.env.get("APNS_BUNDLE_ID")!;
+const APPLE_TEAM_ID = Deno.env.get("APNS_TEAM_ID")!;
+const APPLE_KEY_ID = Deno.env.get("APNS_KEY_ID")!;
+const APPLE_PRIVATE_KEY = Deno.env.get("APNS_PRIVATE_KEY")!;
+
+async function generateAppleClientSecret(): Promise<string> {
+  const header = { alg: "ES256", kid: APPLE_KEY_ID };
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: APPLE_TEAM_ID,
+    iat: now,
+    exp: now + 15777000,
+    aud: "https://appleid.apple.com",
+    sub: APPLE_CLIENT_ID,
+  };
+
+  const encode = (obj: object) =>
+    btoa(JSON.stringify(obj))
+      .replace(/=/g, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+
+  const signingInput = `${encode(header)}.${encode(payload)}`;
+
+  const pemKey = APPLE_PRIVATE_KEY.replace(/\\n/g, "\n");
+  const keyData = pemKey
+    .replace("-----BEGIN PRIVATE KEY-----", "")
+    .replace("-----END PRIVATE KEY-----", "")
+    .replace(/\s/g, "");
+
+  const binaryKey = Uint8Array.from(atob(keyData), (c) => c.charCodeAt(0));
+  const cryptoKey = await crypto.subtle.importKey(
+    "pkcs8",
+    binaryKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
+  );
+
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    cryptoKey,
+    new TextEncoder().encode(signingInput)
+  );
+
+  const sig = btoa(String.fromCharCode(...new Uint8Array(signature)))
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+
+  return `${signingInput}.${sig}`;
+}
+
+async function revokeAppleToken(authorizationCode: string): Promise<void> {
+  const clientSecret = await generateAppleClientSecret();
+
+  const tokenRes = await fetch("https://appleid.apple.com/auth/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: APPLE_CLIENT_ID,
+      client_secret: clientSecret,
+      code: authorizationCode,
+      grant_type: "authorization_code",
+    }),
+  });
+
+  if (!tokenRes.ok) {
+    console.error("Apple token exchange failed:", await tokenRes.text());
+    return;
+  }
+
+  const { refresh_token } = await tokenRes.json();
+  if (!refresh_token) {
+    console.error("No refresh_token received from Apple");
+    return;
+  }
+
+  const revokeRes = await fetch("https://appleid.apple.com/auth/revoke", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: APPLE_CLIENT_ID,
+      client_secret: clientSecret,
+      token: refresh_token,
+      token_type_hint: "refresh_token",
+    }),
+  });
+
+  if (!revokeRes.ok) {
+    console.error("Apple token revoke failed:", await revokeRes.text());
+  }
+}
 
 Deno.serve(async (req) => {
   if (req.method !== "POST") {
@@ -20,7 +113,24 @@ Deno.serve(async (req) => {
     });
   }
 
-  // 사용자 인증
+  let body: { authorizationCode?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { authorizationCode } = body;
+  if (!authorizationCode) {
+    return new Response(JSON.stringify({ error: "missing_authorization_code" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   const authClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
     global: { headers: { Authorization: authHeader } },
   });
@@ -36,7 +146,8 @@ Deno.serve(async (req) => {
   const userId = user.id;
 
   try {
-    // CASCADE FK가 없는 테이블 먼저 명시 삭제
+    await revokeAppleToken(authorizationCode);
+
     await supabase
       .from("user_device_tokens")
       .delete()
@@ -52,8 +163,6 @@ Deno.serve(async (req) => {
       .delete()
       .eq("user_id", userId);
 
-    // auth.users 삭제 → ON DELETE CASCADE로 나머지 테이블 자동 정리
-    // (items, mid_categories, sub_categories, item_quantity_logs, consumption_patterns)
     const { error: deleteError } = await supabase.auth.admin.deleteUser(userId);
     if (deleteError) {
       console.error("deleteUser error:", deleteError);

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,77 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: "missing_authorization" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // 사용자 인증
+  const authClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    global: { headers: { Authorization: authHeader } },
+  });
+  const { data: { user }, error: authError } = await authClient.auth.getUser();
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const userId = user.id;
+
+  try {
+    // CASCADE FK가 없는 테이블 먼저 명시 삭제
+    await supabase
+      .from("user_device_tokens")
+      .delete()
+      .eq("user_id", userId);
+
+    await supabase
+      .from("notification_logs")
+      .delete()
+      .eq("user_id", userId);
+
+    await supabase
+      .from("low_stock_alert_states")
+      .delete()
+      .eq("user_id", userId);
+
+    // auth.users 삭제 → ON DELETE CASCADE로 나머지 테이블 자동 정리
+    // (items, mid_categories, sub_categories, item_quantity_logs, consumption_patterns)
+    const { error: deleteError } = await supabase.auth.admin.deleteUser(userId);
+    if (deleteError) {
+      console.error("deleteUser error:", deleteError);
+      return new Response(
+        JSON.stringify({ error: "Failed to delete account" }),
+        { status: 500, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("delete-account error:", err);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+});


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #

## 🛠 작업 내용 (What I did)
- Apple Token Revoke를 적용하여 회원 탈퇴 기능 구현
- 기존 APNS secrets의 환경변수 재사용
- delete-acount에 generateAppleClientSecret(), revokeAppleToken() 메서드 추가: authorization code -> refresh token -> token revoke

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
