### PR TITLE
Fix/keyboard dismiss tap

### DIFF
--- a/JaengYeo/JaengYeo/View/Common/BaseViewController.swift
+++ b/JaengYeo/JaengYeo/View/Common/BaseViewController.swift
@@ -33,6 +33,7 @@ extension BaseViewController {
         
         let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = false
+        tap.delegate = self
         view.addGestureRecognizer(tap)
     }
     
@@ -81,5 +82,16 @@ extension UIView {
             if let responder = subview.findFirstResponder() { return responder }
         }
         return nil
+    }
+}
+
+extension BaseViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        var view: UIView? = touch.view
+        while let current = view {
+            if current is UIControl { return false}
+            view = current.superview
+        }
+        return true
     }
 }

--- a/JaengYeo/JaengYeo/View/Stock/CategoryEditDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategoryEditDetailViewController.swift
@@ -89,7 +89,6 @@ final class CategoryEditDetailViewController: BaseViewController {
         configureUI()
         configureData()
         configureInputValidation()
-        configureKeyboardDismiss()
         bind()
     }
 }
@@ -230,18 +229,6 @@ private extension CategoryEditDetailViewController {
 
 //MARK: - Configure
 private extension CategoryEditDetailViewController {
-    /// 키보드 닫기 설정
-    func configureKeyboardDismiss() {
-        let tap = UITapGestureRecognizer()
-        tap.cancelsTouchesInView = false
-        view.addGestureRecognizer(tap)
-        
-        tap.rx.event
-            .bind(onNext: { [weak self] _ in
-                self?.view.endEditing(true)
-            })
-            .disposed(by: disposeBag)
-    }
 
     /// 네비게이션 바 설정
     func configureNavigationBar() {


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #

## 🛠 작업 내용 (What I did)
- 키보드가 올라와 있을 경우 버튼을 눌러도 이벤트 발생 x, 키보드만 dismiss되는 버그 발생
- BaseViewController의 dismiss 용 탭 제스처에 UIGestureRecognizerDelegate를 적용하여 UIControl 위 터치는 가로치지 않도록 변경

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
