### PR TITLE
♻️ refactor: 알럿 컴포넌트 크기 조정 및 에러 알럿 이미지 변경

### DIFF
--- a/JaengYeo/JaengYeo/View/Common/AlertController.swift
+++ b/JaengYeo/JaengYeo/View/Common/AlertController.swift
@@ -113,7 +113,7 @@ extension AlertController {
       addSubview(imageView)
       imageView.snp.makeConstraints {
         $0.top.centerX.equalTo(contentLayoutGuide).inset(5)
-        $0.size.equalTo(30)
+        $0.size.equalTo(40)
       }
 
       let titleLabel = StyledLabel(config: .titleSemi16).then {
@@ -121,7 +121,7 @@ extension AlertController {
       }
       addSubview(titleLabel)
       titleLabel.snp.makeConstraints {
-        $0.top.equalTo(imageView.snp.bottom).offset(13)
+        $0.top.equalTo(imageView.snp.bottom).offset(8)
         $0.centerX.equalTo(contentLayoutGuide)
         $0.leading.greaterThanOrEqualTo(contentLayoutGuide)
         $0.trailing.lessThanOrEqualTo(contentLayoutGuide)
@@ -149,7 +149,7 @@ extension AlertController {
     buttons.forEach {
       $0.snp.makeConstraints {
         $0.width.equalTo(70)
-        $0.height.greaterThanOrEqualTo(44)
+        $0.height.equalTo(30)
       }
     }
       buttonStackView.snp.makeConstraints {

--- a/JaengYeo/JaengYeo/View/Register/RegisterViewController.swift
+++ b/JaengYeo/JaengYeo/View/Register/RegisterViewController.swift
@@ -375,7 +375,7 @@ extension RegisterViewController: AVCapturePhotoCaptureDelegate {
 extension RegisterViewController {
     private func showErrorAlert(title: String, message: String) {
         let alert = AlertController(
-            image: .warningIcon,
+            image: .alertBlue,
             title: title,
             message: message,
             actions: [.default("확인")]


### PR DESCRIPTION
- AlertController 아이콘/타이틀 여백/버튼 높이 조정
- RegisterViewController 에러 알럿 이미지를 alertBlue로 변경

## 🎫 관련 이슈 (Linked Issues)
Closes #

## 🛠 작업 내용 (What I did)
- 컴포넌트 수치 조정, 아이콘 변경

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
