### PR TITLE
🐛fix: 화면 전환 및 UI 표시 이슈 개선

### DIFF
--- a/JaengYeo/JaengYeo/Utils/Configuration/ButtonConfiguration.swift
+++ b/JaengYeo/JaengYeo/Utils/Configuration/ButtonConfiguration.swift
@@ -127,6 +127,13 @@ extension ButtonTitleConfiguration {
         selectedColor: .gray300,
         disabledColor: .white
     )
+    
+    static let buttonNormalTitle = ButtonTitleConfiguration (
+        font: .systemFont(ofSize: 12, weight: .regular),
+        normalColor: .white,
+        selectedColor: .gray300,
+        disabledColor: .white
+    )
 }
 
 
@@ -151,7 +158,6 @@ extension ButtonAppearanceConfiguration {
         cornerRadius: 12,
         borderWidth: 0,
         borderColor: UIColor.clear
-
     )
     
     static let textEdgeAppearance = ButtonAppearanceConfiguration(
@@ -194,12 +200,32 @@ extension ButtonAppearanceConfiguration {
         borderColor: UIColor.clear
     )
     
-    static let cancelAppearance = ButtonAppearanceConfiguration(
+    static let buttonCancelAppearance = ButtonAppearanceConfiguration(
         backgroundColor: .gray50,
         selectedBackgroundColor: .gray100,
         highlightedBackgroundColor: .gray100,
         disabledBackgroundColor: .gray300,
-        cornerRadius: 12,
+        cornerRadius: 8,
+        borderWidth: 0,
+        borderColor: UIColor.clear
+    )
+    
+    static let buttonNormalAppearance = ButtonAppearanceConfiguration (
+        backgroundColor: .accent,
+        selectedBackgroundColor: .accent,
+        highlightedBackgroundColor: .primary700,
+        disabledBackgroundColor: UIColor.clear,
+        cornerRadius: 8,
+        borderWidth: 0,
+        borderColor: UIColor.clear
+    )
+    
+    static let buttonDeleteAppearance = ButtonAppearanceConfiguration(
+        backgroundColor: .primaryLightRed,
+        selectedBackgroundColor: .primary700,
+        highlightedBackgroundColor: UIColor.clear,
+        disabledBackgroundColor: UIColor.clear,
+        cornerRadius: 8,
         borderWidth: 0,
         borderColor: UIColor.clear
     )

--- a/JaengYeo/JaengYeo/View/Common/AlertController.swift
+++ b/JaengYeo/JaengYeo/View/Common/AlertController.swift
@@ -85,11 +85,11 @@ extension AlertController {
       self.buttons = actions.map {
         let configurations: (title: ButtonTitleConfiguration, appearance: ButtonAppearanceConfiguration) = switch $0.style {
         case .default:
-          (.defaultTitle, .defaultAppearance)
+          (.defaultTitle, .buttonNormalAppearance)
         case .destructive:
-            (.redTitle, .redAppearance)
+            (.redTitle, .buttonDeleteAppearance)
         case .cancel:
-            (.cancelTitle, .cancelAppearance)
+            (.cancelTitle, .buttonCancelAppearance)
         }
         return StyledButton(
           title: $0.title,
@@ -118,6 +118,7 @@ extension AlertController {
 
       let titleLabel = StyledLabel(config: .titleSemi16).then {
         $0.text = title
+        $0.textAlignment = .center
       }
       addSubview(titleLabel)
       titleLabel.snp.makeConstraints {

--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -231,8 +231,7 @@ extension ProductCell {
             }
         }
         
-        if cellType == .detailType || cellType == .registType || cellType == .homeType
-        {
+        if cellType == .detailType || cellType == .registType || cellType == .homeType {
             updateDescriptionStack(
                 stackView: productSubDescriptionStack,
                 freshness: nil,

--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -55,7 +55,7 @@ final class ProductCell: UICollectionViewListCell{
                 upDownCountView.isHidden = true
             
             case .homeType:
-                productSubDescriptionStack.isHidden = true
+                productSubDescriptionStack.isHidden = false
                 productCountView.isHidden = true
                 upDownCountView.isHidden = false
                 var config = backgroundConfiguration ?? UIBackgroundConfiguration.clear()
@@ -231,7 +231,8 @@ extension ProductCell {
             }
         }
         
-        if cellType == .detailType || cellType == .registType {
+        if cellType == .detailType || cellType == .registType || cellType == .homeType
+        {
             updateDescriptionStack(
                 stackView: productSubDescriptionStack,
                 freshness: nil,

--- a/JaengYeo/JaengYeo/View/Home/HomeViewController.swift
+++ b/JaengYeo/JaengYeo/View/Home/HomeViewController.swift
@@ -172,13 +172,12 @@ extension HomeViewController {
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProductCell.id, for: indexPath) as? ProductCell else { return UICollectionViewCell() }
                 var descriptions = [summary.mainCategory]
                 if let midCategory = summary.midCategoryName { descriptions.append(midCategory) }
-                descriptions.append(self.dateFormatter.string(from: summary.createdAt))
                 cell.updateUI(
                     type: .homeType,
                     title: summary.name,
                     freshness: nil,
                     descriptions: descriptions,
-                    subdescriptions: nil,
+                    subdescriptions: [self.dateFormatter.string(from: summary.createdAt)],
                     count: summary.quantity,
                     image: summary.image ?? summary.subCategoryIconName.flatMap { UIImage(named: $0) } //TODO: 추후에 수정 필요
                 )

--- a/JaengYeo/JaengYeo/View/OnBorading/OnboardingFifthView.swift
+++ b/JaengYeo/JaengYeo/View/OnBorading/OnboardingFifthView.swift
@@ -29,12 +29,12 @@ final class OnboardingFifthView: UIView {
 
     private let firstImageView = UIImageView().then {
         $0.image = UIImage(named: "Onbording5-1")
-        $0.contentMode = .scaleAspectFit
+        $0.contentMode = .scaleAspectFill
     }
 
     private let secondImageView = UIImageView().then {
         $0.image = UIImage(named: "Onbording5-2")
-        $0.contentMode = .scaleAspectFit
+        $0.contentMode = .scaleAspectFill
     }
 
     //MARK: - Init
@@ -71,13 +71,17 @@ private extension OnboardingFifthView {
         firstImageView.snp.makeConstraints {
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(72)
             $0.centerX.equalToSuperview()
-            $0.size.equalTo(CGSize(width: 343, height: 40))
+            $0.height.equalTo(40)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().inset(16)
         }
 
         secondImageView.snp.makeConstraints {
             $0.top.equalTo(firstImageView.snp.bottom).offset(72)
             $0.centerX.equalToSuperview()
-            $0.size.equalTo(CGSize(width: 343, height: 88))
+            $0.height.equalTo(88)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().inset(16)
             $0.bottom.equalToSuperview().inset(24)
         }
     }

--- a/JaengYeo/JaengYeo/View/OnBorading/OnboardingThirdView.swift
+++ b/JaengYeo/JaengYeo/View/OnBorading/OnboardingThirdView.swift
@@ -29,12 +29,12 @@ final class OnboardingThirdView: UIView {
 
     private let firstImageView = UIImageView().then {
         $0.image = UIImage(named: "Onbording3-1")
-        $0.contentMode = .scaleAspectFit
+        $0.contentMode = .scaleAspectFill
     }
 
     private let secondImageView = UIImageView().then {
         $0.image = UIImage(named: "Onbording3-2")
-        $0.contentMode = .scaleAspectFit
+        $0.contentMode = .scaleAspectFill
     }
 
     private let bottomTitleLabel = StyledLabel(config: .bodyMedium14).then {
@@ -91,13 +91,17 @@ private extension OnboardingThirdView {
         firstImageView.snp.makeConstraints {
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(72)
             $0.centerX.equalToSuperview()
-            $0.size.equalTo(CGSize(width: 343, height: 75))
+            $0.height.equalTo(75)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().inset(16)
         }
 
         secondImageView.snp.makeConstraints {
             $0.top.equalTo(firstImageView.snp.bottom).offset(72)
             $0.centerX.equalToSuperview()
-            $0.size.equalTo(CGSize(width: 343, height: 87))
+            $0.height.equalTo(87)
+            $0.leading.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().inset(16)
         }
 
         bottomTitleLabel.snp.makeConstraints {

--- a/JaengYeo/JaengYeo/View/Stock/CategoryEditDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategoryEditDetailViewController.swift
@@ -77,6 +77,7 @@ final class CategoryEditDetailViewController: BaseViewController {
         self.mode = mode
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        hidesBottomBarWhenPushed = true
     }
 
     required init?(coder: NSCoder) {
@@ -246,6 +247,18 @@ private extension CategoryEditDetailViewController {
     /// 네비게이션 바 설정
     func configureNavigationBar() {
         title = mode.navigationTitle
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .white
+        appearance.shadowColor = .clear
+        appearance.titleTextAttributes = [
+            .font: LabelConfiguration.titleSemi18.font,
+            .foregroundColor: UIColor.gray800
+        ]
+        
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
         navigationController?.navigationBar.tintColor = .gray800
     }
 

--- a/JaengYeo/JaengYeo/View/Stock/CategoryEditViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategoryEditViewController.swift
@@ -89,6 +89,7 @@ final class CategoryEditViewController: BaseViewController {
     init(viewModel: CategoryEditViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        hidesBottomBarWhenPushed = true
     }
 
     required init?(coder: NSCoder) {

--- a/JaengYeo/JaengYeo/View/Stock/CategorySelectionItemCell.swift
+++ b/JaengYeo/JaengYeo/View/Stock/CategorySelectionItemCell.swift
@@ -35,7 +35,7 @@ final class CategorySelectionItemCell: UICollectionViewCell {
     }
 
     private let imageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFit
+        $0.contentMode = .scaleAspectFill
     }
 
     private let titleLabel = StyledLabel(config: .body12).then {
@@ -133,7 +133,7 @@ private extension CategorySelectionItemCell {
 
         imageView.snp.makeConstraints {
             $0.center.equalToSuperview()
-            $0.size.equalTo(24)
+            $0.size.equalTo(40)
         }
 
         titleLabel.snp.makeConstraints {

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
@@ -34,7 +34,8 @@ final class ProductDetailViewController: BaseViewController {
     init(viewModel: ProductDetailViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        overrideUserInterfaceStyle = .light
+        overrideUserInterfaceStyle = .light         
+        title = "상세 정보"
         hidesBottomBarWhenPushed = true
     }
 
@@ -142,7 +143,6 @@ extension ProductDetailViewController {
 
     func configureNavigationBar() {
         title = "상세 정보"
-        hidesBottomBarWhenPushed = true
 
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
@@ -35,6 +35,7 @@ final class ProductDetailViewController: BaseViewController {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
         overrideUserInterfaceStyle = .light
+        hidesBottomBarWhenPushed = true
     }
 
     required init?(coder: NSCoder) {
@@ -43,6 +44,7 @@ final class ProductDetailViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNavigationBar()
         configureUI()
         bind()
     }
@@ -86,7 +88,6 @@ extension ProductDetailViewController {
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] displayModel in
                 guard let self else { return }
-                self.title = "상세 정보"
                 self.productDetailView.updateUI(displayModel: displayModel)
             })
             .disposed(by: disposeBag)
@@ -139,6 +140,25 @@ extension ProductDetailViewController {
 
 extension ProductDetailViewController {
 
+    func configureNavigationBar() {
+        title = "상세 정보"
+        hidesBottomBarWhenPushed = true
+
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .white
+        appearance.shadowColor = .clear
+        appearance.titleTextAttributes = [
+            .font: LabelConfiguration.titleSemi18.font,
+            .foregroundColor: UIColor.gray800
+        ]
+        
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
+        navigationController?.navigationBar.tintColor = .gray800
+    }
+    
     private func configureUI() {
         view.backgroundColor = .white
         view.addSubview(productDetailView)

--- a/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
@@ -95,6 +95,7 @@ final class StockSearchViewController: BaseViewController {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
         overrideUserInterfaceStyle = .light
+        hidesBottomBarWhenPushed = true
     }
 
     required init?(coder: NSCoder) {

--- a/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockViewController.swift
@@ -392,6 +392,7 @@ private extension StockViewController {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = .white
+        appearance.shadowColor = .clear
         appearance.titleTextAttributes = [
             .font: LabelConfiguration.titleSemi18.font,
             .foregroundColor: UIColor.gray800

--- a/JaengYeo/JaengYeo/ViewModel/MyPage/MyPageViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/MyPage/MyPageViewModel.swift
@@ -80,7 +80,7 @@ enum MyPageMenu: CaseIterable {
         case .appPermission:
             return URL(string: UIApplication.openSettingsURLString)
         case .appVersion:
-            return URL(string: "https://apps.apple.com/app/id0000000000")
+            return URL(string: "https://apps.apple.com/kr/app/쟁여/id6763179807")
         case .iconCopyright:
             return URL(string: "https://icons8.com")
         default:

--- a/JaengYeo/JaengYeo/ViewModel/MyPage/MyPageViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/MyPage/MyPageViewModel.swift
@@ -80,7 +80,7 @@ enum MyPageMenu: CaseIterable {
         case .appPermission:
             return URL(string: UIApplication.openSettingsURLString)
         case .appVersion:
-            return URL(string: "https://apps.apple.com/kr/app/쟁여/id6763179807")
+            return URL(string: "https://apps.apple.com/app/id6763179807")
         case .iconCopyright:
             return URL(string: "https://icons8.com")
         default:


### PR DESCRIPTION
## 🛠 작업 내용 (What I did)
- 상품 상세 화면 진입 시 탭바가 노출되지 않도록 hidesBottomBarWhenPushed 적용
- 분류 편집/분류 상세 화면에서도 탭바가 숨겨지도록 처리
- 상품 상세 화면 네비게이션 타이틀을 상세 정보로 고정하고 네비게이션 바 스타일 정리
- Alert 버튼 스타일을 일반/취소/삭제 버튼 용도에 맞게 분리
- Alert 타이틀 중앙 정렬 적용
- 홈 최근 상품 셀에서 등록일을 보조 설명 영역으로 분리해 표시
- 홈 타입 상품 셀에서도 보조 설명 영역이 정상 표시되도록 수정
- 온보딩 3, 5번째 화면 이미지 비율 및 좌우 여백 조정
- 분류 선택 셀 아이콘 크기 확대 및 이미지 표시 방식 조정
- 재고 화면 네비게이션 바 하단 라인 제거
- 마이페이지 앱 버전 메뉴의 App Store 링크를 실제 앱 링크로 변경

## 💻 구현 상세 (Implementation Details)
- ButtonConfiguration에 Alert 전용 버튼 스타일 추가
- AlertController에서 액션 타입별 버튼 스타일 매핑 변경
- ProductCell의 homeType 표시 조건 정리
- HomeViewController 최근 등록 셀의 설명/보조설명 데이터 분리
- CategoryEditViewController, CategoryEditDetailViewController, ProductDetailViewController에서 push 전 탭바 숨김 처리
- OnboardingThirdView, OnboardingFifthView 이미지 제약을 고정 width 대신 좌우 16 inset 기반으로 변경