### PR TITLE
[장바구니] 장바구니 탭 및 목록 화면 구현 및 아이템 추가 플로우 구현

### DIFF
--- a/JaengYeo/JaengYeo/Application/AppCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/AppCoordinator.swift
@@ -14,6 +14,7 @@ private enum Tab: Int {
     case home = 0
     case register = 1
     case stock = 2
+    case cart = 3
 }
 
 final class AppCoordinator {
@@ -160,11 +161,24 @@ final class AppCoordinator {
             coreDataManager: coreDataManager,
             authManager: authManager
         )
-        childCoordinators = [homeCoordinator, registerCoordinator, stockCoordinator]
+        
+        let cartCoordinator = CartCoordinator(
+            coreDataManager: coreDataManager,
+            authManager: authManager
+        )
+        
+        childCoordinators = [
+            homeCoordinator,
+            registerCoordinator,
+            stockCoordinator,
+            cartCoordinator
+        ]
+        
         let mainController = MainController(
             homeNavigationController: homeCoordinator.navigationController,
             registerNavigationController: registerCoordinator.navigationController,
-            stockNavigationController: stockCoordinator.navigationController
+            stockNavigationController: stockCoordinator.navigationController,
+            cartNavigationController: cartCoordinator.navigationController
         )
         
         homeCoordinator.navigateToCategory
@@ -200,6 +214,13 @@ final class AppCoordinator {
             .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak mainController] in
                 mainController?.selectedIndex = Tab.register.rawValue
+            })
+            .disposed(by: disposeBag)
+        
+        cartCoordinator.navigateToRegister
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak mainController] in
+                mainController?.selectedIndex = Tab.cart.rawValue
             })
             .disposed(by: disposeBag)
         

--- a/JaengYeo/JaengYeo/Application/AppCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/AppCoordinator.swift
@@ -180,6 +180,14 @@ final class AppCoordinator {
             stockNavigationController: stockCoordinator.navigationController,
             cartNavigationController: cartCoordinator.navigationController
         )
+
+        mainController.onCartTabSelected = { [weak mainController, weak cartCoordinator] in
+            guard let navigationController = mainController?.selectedViewController as? UINavigationController else {
+                return
+            }
+
+            cartCoordinator?.pushCartViewController(from: navigationController)
+        }
         
         homeCoordinator.navigateToCategory
             .observe(on: MainScheduler.instance)
@@ -220,7 +228,7 @@ final class AppCoordinator {
         cartCoordinator.navigateToRegister
             .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak mainController] in
-                mainController?.selectedIndex = Tab.cart.rawValue
+                mainController?.selectedIndex = Tab.register.rawValue
             })
             .disposed(by: disposeBag)
         

--- a/JaengYeo/JaengYeo/Application/CartCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/CartCoordinator.swift
@@ -1,0 +1,31 @@
+//
+//  CartCoordinator.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 4/28/26.
+//
+
+import UIKit
+import RxSwift
+import RxRelay
+
+final class CartCoordinator {
+    let navigationController: UINavigationController
+    let navigateToRegister = PublishSubject<Void>()
+    private let coreDataManager: CoreDataManagerProtocol
+    private let authManager: AuthManagerProtocol
+    
+    init(coreDataManager: CoreDataManagerProtocol, authManager: AuthManagerProtocol) {
+        self.coreDataManager = coreDataManager
+        self.authManager = authManager
+        
+        let viewModel = CartViewModel(coreDataManager: coreDataManager)
+        let viewController = CartViewController(viewModel: viewModel)
+        navigationController = BaseNavigationController(rootViewController: viewController)
+        navigationController.tabBarItem = UITabBarItem(
+            title: "장바구니",
+            image: UIImage(named: "bagIcon"),
+            selectedImage: UIImage(named: "bagFillIcon")
+        )
+    }
+}

--- a/JaengYeo/JaengYeo/Application/CartCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/CartCoordinator.swift
@@ -19,15 +19,30 @@ final class CartCoordinator {
         self.coreDataManager = coreDataManager
         self.authManager = authManager
         
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        navigationController = BaseNavigationController(rootViewController: viewController)
+        navigationController.tabBarItem = UITabBarItem(
+            title: "목록",
+            image: UIImage(named: "list"),
+            selectedImage: UIImage(named: "list")
+        )
+    }
+}
+
+extension CartCoordinator {
+    /// 장바구니 화면 전환
+    func pushCartViewController(from navigationController: UINavigationController) {
+        guard !(navigationController.topViewController is CartViewController) else {
+            return
+        }
+
         let viewModel = CartViewModel(coreDataManager: coreDataManager)
         let viewController = CartViewController(viewModel: viewModel)
-        navigationController = BaseNavigationController(rootViewController: viewController)
         viewController.delegate = self
-        navigationController.tabBarItem = UITabBarItem(
-            title: "장바구니",
-            image: UIImage(named: "bagIcon"),
-            selectedImage: UIImage(named: "bagFillIcon")
-        )
+        viewController.hidesBottomBarWhenPushed = true
+
+        navigationController.pushViewController(viewController, animated: true)
     }
 }
 

--- a/JaengYeo/JaengYeo/Application/CartCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/CartCoordinator.swift
@@ -22,10 +22,17 @@ final class CartCoordinator {
         let viewModel = CartViewModel(coreDataManager: coreDataManager)
         let viewController = CartViewController(viewModel: viewModel)
         navigationController = BaseNavigationController(rootViewController: viewController)
+        viewController.delegate = self
         navigationController.tabBarItem = UITabBarItem(
             title: "장바구니",
             image: UIImage(named: "bagIcon"),
             selectedImage: UIImage(named: "bagFillIcon")
         )
+    }
+}
+
+extension CartCoordinator: CartViewControllerDelegate {
+    func didTapCartAddButton() {
+        navigateToRegister.onNext(())
     }
 }

--- a/JaengYeo/JaengYeo/Application/CartCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/CartCoordinator.swift
@@ -14,6 +14,7 @@ final class CartCoordinator {
     let navigateToRegister = PublishSubject<Void>()
     private let coreDataManager: CoreDataManagerProtocol
     private let authManager: AuthManagerProtocol
+    private weak var currentNavigationController: UINavigationController?
     
     init(coreDataManager: CoreDataManagerProtocol, authManager: AuthManagerProtocol) {
         self.coreDataManager = coreDataManager
@@ -24,8 +25,8 @@ final class CartCoordinator {
         navigationController = BaseNavigationController(rootViewController: viewController)
         navigationController.tabBarItem = UITabBarItem(
             title: "목록",
-            image: UIImage(named: "list"),
-            selectedImage: UIImage(named: "list")
+            image: UIImage(named: "List"),
+            selectedImage: UIImage(named: "List")
         )
     }
 }
@@ -36,6 +37,7 @@ extension CartCoordinator {
         guard !(navigationController.topViewController is CartViewController) else {
             return
         }
+        currentNavigationController = navigationController
 
         let viewModel = CartViewModel(coreDataManager: coreDataManager)
         let viewController = CartViewController(viewModel: viewModel)
@@ -47,7 +49,21 @@ extension CartCoordinator {
 }
 
 extension CartCoordinator: CartViewControllerDelegate {
-    func didTapCartAddButton() {
-        navigateToRegister.onNext(())
+    func didTapExistingProductButton() {
+    }
+
+    func didTapNewProductButton() {
+        let viewModel = CartAddItemViewModel(coreDataManager: coreDataManager)
+        let viewController = CartAddItemViewController(viewModel: viewModel)
+        currentNavigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func didSelectCartItem(_ item: CartItem) {
+        let viewModel = CartAddItemViewModel(
+            coreDataManager: coreDataManager,
+            item: item
+        )
+        let viewController = CartAddItemViewController(viewModel: viewModel)
+        currentNavigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/JaengYeo/JaengYeo/Assets.xcassets/List.imageset/Contents.json
+++ b/JaengYeo/JaengYeo/Assets.xcassets/List.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "List.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JaengYeo/JaengYeo/Assets.xcassets/List.imageset/List.svg
+++ b/JaengYeo/JaengYeo/Assets.xcassets/List.imageset/List.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="5" y="4" width="14" height="17" rx="2" stroke="#333333" stroke-width="1.5"/>
+<path d="M9 9H15" stroke="#333333" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M9 13H15" stroke="#333333" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M9 17H13" stroke="#333333" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/JaengYeo/JaengYeo/Assets.xcassets/ListAdd.imageset/Contents.json
+++ b/JaengYeo/JaengYeo/Assets.xcassets/ListAdd.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "ListAdd.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JaengYeo/JaengYeo/Assets.xcassets/ListAdd.imageset/ListAdd.svg
+++ b/JaengYeo/JaengYeo/Assets.xcassets/ListAdd.imageset/ListAdd.svg
@@ -1,0 +1,8 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 13.0353V17.5353C19 19.4209 19 20.3637 18.4142 20.9495C17.8284 21.5353 16.8856 21.5353 15 21.5353H9C7.11438 21.5353 6.17157 21.5353 5.58579 20.9495C5 20.3637 5 19.4209 5 17.5353V8.53531C5 6.64969 5 5.70688 5.58579 5.1211C6.17157 4.53531 7.11438 4.53531 9 4.53531H12" stroke="#333333" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M9 13.5353H15" stroke="#333333" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M9 17.5353H13" stroke="#333333" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M19 2.25407L19 8.74594" stroke="#333333" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M22.2459 5.5L15.7541 5.5" stroke="#333333" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M9 9.53531H15" stroke="#333333" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/JaengYeo/JaengYeo/Assets.xcassets/List_fill.imageset/Contents.json
+++ b/JaengYeo/JaengYeo/Assets.xcassets/List_fill.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "List_fill.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JaengYeo/JaengYeo/Assets.xcassets/List_fill.imageset/List_fill.svg
+++ b/JaengYeo/JaengYeo/Assets.xcassets/List_fill.imageset/List_fill.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="5" y="4" width="14" height="17" rx="2" fill="#333333" stroke="#333333" stroke-width="1.5"/>
+<path d="M9 9H15" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M9 13H15" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M9 17H13" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/JaengYeo/JaengYeo/Assets.xcassets/offIcon.imageset/Contents.json
+++ b/JaengYeo/JaengYeo/Assets.xcassets/offIcon.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "offIcon.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JaengYeo/JaengYeo/Assets.xcassets/offIcon.imageset/offIcon.svg
+++ b/JaengYeo/JaengYeo/Assets.xcassets/offIcon.imageset/offIcon.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2.5" y="2.5" width="19" height="19" rx="9.5" fill="#F7F7F7"/>
+<rect x="2.5" y="2.5" width="19" height="19" rx="9.5" stroke="#E6E6E6"/>
+</svg>

--- a/JaengYeo/JaengYeo/Data/CoreData/CartItemEntity+CoreDataProperties.swift
+++ b/JaengYeo/JaengYeo/Data/CoreData/CartItemEntity+CoreDataProperties.swift
@@ -22,6 +22,7 @@ extension CartItemEntity {
     @NSManaged public var referenceId: UUID?
     @NSManaged public var name: String?
     @NSManaged public var mainCategory: String?
+    @NSManaged public var quantity: Int32
     @NSManaged public var createDate: Date?
 
 }
@@ -37,6 +38,7 @@ extension CartItemEntity {
             referenceId: referenceId,
             name: name ?? "",
             mainCategory: mainCategory ?? "",
+            quantity: Int(quantity),
             createdAt: createDate
         )
     }

--- a/JaengYeo/JaengYeo/Data/CoreData/CoreDataManager.swift
+++ b/JaengYeo/JaengYeo/Data/CoreData/CoreDataManager.swift
@@ -979,6 +979,7 @@ extension CoreDataManager {
         entity.referenceId = payload.referenceId
         entity.name = payload.name
         entity.mainCategory = payload.mainCategory
+        entity.quantity = Int32(payload.quantity)
         entity.createDate = payload.createdAt
 
         do {
@@ -1017,6 +1018,7 @@ extension CoreDataManager {
         entity.referenceId = payload.referenceId
         entity.name = payload.name
         entity.mainCategory = payload.mainCategory
+        entity.quantity = Int32(payload.quantity)
         entity.createDate = payload.createdAt
 
         do {
@@ -1061,6 +1063,7 @@ extension CoreDataManager {
             referenceId: entity.referenceId,
             name: entity.name ?? "",
             mainCategory: entity.mainCategory ?? "",
+            quantity: Int(entity.quantity),
             createdAt: entity.createDate ?? Date()
         )
     }

--- a/JaengYeo/JaengYeo/JaengYeo.xcdatamodeld/JaengYeo.xcdatamodel/contents
+++ b/JaengYeo/JaengYeo/JaengYeo.xcdatamodeld/JaengYeo.xcdatamodel/contents
@@ -5,6 +5,7 @@
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="mainCategory" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="quantity" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="referenceId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
     <entity name="MidCategoryEntity" representedClassName="MidCategoryEntity" syncable="YES">

--- a/JaengYeo/JaengYeo/Model/DTO/CoreData/CartItemPayload.swift
+++ b/JaengYeo/JaengYeo/Model/DTO/CoreData/CartItemPayload.swift
@@ -13,6 +13,7 @@ struct CartItemPayload {
     let referenceId: UUID?
     let name: String
     let mainCategory: String
+    let quantity: Int
     let createdAt: Date
 }
 
@@ -25,7 +26,21 @@ extension CartItemPayload {
             referenceId: referenceId,
             name: name,
             mainCategory: mainCategory,
+            quantity: quantity,
             createdAt: createdAt
+        )
+    }
+}
+
+extension CartItem {
+    var toPayload: CartItemPayload {
+        CartItemPayload(
+            id: id,
+            referenceId: referenceId,
+            name: name,
+            mainCategory: mainCategory,
+            quantity: quantity,
+            createdAt: createdAt ?? Date()
         )
     }
 }

--- a/JaengYeo/JaengYeo/Model/Domain/CoreData/CartItem.swift
+++ b/JaengYeo/JaengYeo/Model/Domain/CoreData/CartItem.swift
@@ -13,6 +13,7 @@ struct CartItem: Hashable {
     let referenceId: UUID?
     let name: String
     let mainCategory: String
+    let quantity: Int
     let createdAt: Date?
 }
 
@@ -23,9 +24,35 @@ extension CartItem {
         entity.referenceId = referenceId
         entity.name = name
         entity.mainCategory = mainCategory
+        entity.quantity = Int32(quantity)
         entity.createDate = createdAt
 
         return entity
     }
 }
 
+extension CartItem {
+    static let maxQuantity = 999
+
+    func increased() -> CartItem {
+        CartItem(
+            id: id,
+            referenceId: referenceId,
+            name: name,
+            mainCategory: mainCategory,
+            quantity: min(quantity + 1, Self.maxQuantity),
+            createdAt: createdAt
+        )
+    }
+
+    func decreased() -> CartItem {
+        CartItem(
+            id: id,
+            referenceId: referenceId,
+            name: name,
+            mainCategory: mainCategory,
+            quantity: max(quantity - 1, 1),
+            createdAt: createdAt
+        )
+    }
+}

--- a/JaengYeo/JaengYeo/View/Cart/CartAddItemView.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartAddItemView.swift
@@ -1,0 +1,266 @@
+//
+//  CartAddItemView.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 5/3/26.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class CartAddItemView: UIView {
+
+    //MARK: - Components
+    private let scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = false
+    }
+
+    private let contentView = UIView()
+
+    private let stackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 32
+    }
+
+    let nameField = UITextField().then {
+        $0.font = LabelConfiguration.titleSemi16.font
+        $0.textColor = .gray800
+        $0.attributedPlaceholder = NSAttributedString(
+            string: "상품명을 입력해주세요. (최대 20자)",
+            attributes: [
+                .foregroundColor: UIColor.gray300,
+                .font: LabelConfiguration.body14.font
+            ]
+        )
+    }
+
+    let quantityField = UITextField().then {
+        $0.font = LabelConfiguration.titleSemi16.font
+        $0.textColor = .gray800
+        $0.keyboardType = .numberPad
+        $0.attributedPlaceholder = NSAttributedString(
+            string: "수량을 입력해주세요. (최대 999)",
+            attributes: [
+                .foregroundColor: UIColor.gray300,
+                .font: LabelConfiguration.body14.font
+            ]
+        )
+    }
+
+    let foodButton = UIButton().then {
+        $0.setTitle(MainCategory.foodstuff.rawValue, for: .normal)
+        $0.layer.cornerRadius = 12
+        $0.layer.borderWidth = 1
+    }
+
+    let householdButton = UIButton().then {
+        $0.setTitle(MainCategory.household.rawValue, for: .normal)
+        $0.layer.cornerRadius = 12
+        $0.layer.borderWidth = 1
+    }
+
+    private let bottomView = UIView().then {
+        $0.backgroundColor = .white
+    }
+
+    let deleteButton = StyledButton(
+        title: "삭제",
+        titleConfiguration: .redTitle,
+        appearanceConfiguration: .redAppearance
+    )
+
+    let saveButton = StyledButton(
+        title: "저장",
+        titleConfiguration: .defaultTitle,
+        appearanceConfiguration: .defaultAppearance
+    )
+
+    //MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+//MARK: - Public
+extension CartAddItemView {
+    /// 화면 모드에 맞게 하단 버튼 업데이트
+    func updateMode(isEdit: Bool) {
+        deleteButton.isHidden = !isEdit
+        saveButton.updateTitle(isEdit ? "수정" : "저장")
+        configureBottomButtonConstraints(isEdit: isEdit)
+    }
+
+    /// 대분류 버튼 상태 업데이트
+    func updateCategoryButtons(selected: MainCategory?) {
+        updateButton(foodButton, isSelected: selected == .foodstuff)
+        updateButton(householdButton, isSelected: selected == .household)
+    }
+}
+
+//MARK: - Configure UI
+extension CartAddItemView {
+    func configureUI() {
+        backgroundColor = .white
+
+        let nameGroup = makeFieldGroup(title: "상품명*", field: nameField)
+        let quantityGroup = makeFieldGroup(title: "수량*", field: quantityField)
+        let categoryGroup = makeCategoryGroup()
+
+        [nameGroup, quantityGroup, categoryGroup].forEach {
+            stackView.addArrangedSubview($0)
+        }
+
+        contentView.addSubview(stackView)
+        scrollView.addSubview(contentView)
+
+        addSubview(scrollView)
+        addSubview(bottomView)
+        bottomView.addSubview(deleteButton)
+        bottomView.addSubview(saveButton)
+
+        bottomView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalTo(saveButton.snp.top).offset(-8)
+        }
+
+        keyboardLayoutGuide.usesBottomSafeArea = true
+        updateMode(isEdit: false)
+
+        scrollView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(bottomView.snp.top)
+        }
+
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+        }
+
+        stackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(12)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.lessThanOrEqualToSuperview().offset(-16)
+        }
+    }
+
+    func configureBottomButtonConstraints(isEdit: Bool) {
+        if isEdit {
+            deleteButton.snp.remakeConstraints {
+                $0.leading.equalToSuperview().offset(24)
+                $0.bottom.equalTo(keyboardLayoutGuide.snp.top).offset(-8)
+                $0.width.equalTo(89)
+                $0.height.equalTo(48)
+            }
+
+            saveButton.snp.remakeConstraints {
+                $0.leading.equalTo(deleteButton.snp.trailing).offset(16)
+                $0.trailing.equalToSuperview().inset(16)
+                $0.centerY.equalTo(deleteButton)
+                $0.height.equalTo(48)
+            }
+            return
+        }
+
+        saveButton.snp.remakeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalTo(keyboardLayoutGuide.snp.top).offset(-8)
+            $0.height.equalTo(48)
+        }
+    }
+}
+
+//MARK: - Components
+private extension CartAddItemView {
+    func makeFieldGroup(title: String, field: UITextField) -> UIView {
+        let container = UIView()
+
+        let titleLabel = UILabel().then {
+            $0.text = title
+            $0.font = LabelConfiguration.bodyMedium14.font
+            $0.textColor = .gray600
+        }
+
+        let separator = UIView().then {
+            $0.backgroundColor = .gray100
+        }
+
+        [titleLabel, field, separator].forEach {
+            container.addSubview($0)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(32)
+        }
+
+        field.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom)
+            $0.leading.trailing.equalToSuperview().inset(4)
+            $0.height.equalTo(36)
+        }
+
+        separator.snp.makeConstraints {
+            $0.top.equalTo(field.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+
+        return container
+    }
+
+    func makeCategoryGroup() -> UIView {
+        let container = UIView()
+
+        let titleLabel = UILabel().then {
+            $0.text = "대분류*"
+            $0.font = LabelConfiguration.bodyMedium14.font
+            $0.textColor = .gray600
+        }
+
+        let buttonStackView = UIStackView().then {
+            $0.axis = .horizontal
+            $0.distribution = .fillEqually
+            $0.spacing = 17
+        }
+
+        [foodButton, householdButton].forEach {
+            buttonStackView.addArrangedSubview($0)
+        }
+
+        [titleLabel, buttonStackView].forEach {
+            container.addSubview($0)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(32)
+        }
+
+        buttonStackView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(4)
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalTo(44)
+        }
+
+        return container
+    }
+
+    func updateButton(_ button: UIButton, isSelected: Bool) {
+        button.layer.borderColor = (isSelected ? UIColor.accent : UIColor.gray300).cgColor
+        button.layer.borderWidth = isSelected ? 2 : 1
+        button.setTitleColor(isSelected ? .accent : .gray500, for: .normal)
+        button.titleLabel?.font = isSelected
+            ? LabelConfiguration.bodyMedium14.font
+            : LabelConfiguration.body14.font
+    }
+}
+
+#Preview {
+    CartAddItemView()
+}

--- a/JaengYeo/JaengYeo/View/Cart/CartAddItemViewController.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartAddItemViewController.swift
@@ -1,0 +1,269 @@
+//
+//  CartAddItemViewController.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 5/3/26.
+//
+
+import RxCocoa
+import RxSwift
+import UIKit
+
+final class CartAddItemViewController: BaseViewController {
+
+    //MARK: - Input Limit
+    private enum InputLimit {
+        static let productName = 20
+        static let quantity = 999
+    }
+
+    //MARK: - Properties
+    override var handlesKeyboardInset: Bool { false }
+
+    private let disposeBag = DisposeBag()
+    private let viewModel: CartAddItemViewModel
+
+    //MARK: - Components
+    private let mainView = CartAddItemView()
+
+    //MARK: - Init
+    init(viewModel: CartAddItemViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        hidesBottomBarWhenPushed = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = mainView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationBar()
+        configureMode()
+        restoreFields()
+        configureInputValidation()
+        bind()
+    }
+}
+
+//MARK: - Binding
+extension CartAddItemViewController {
+    func bind() {
+        let confirmTapped = mainView.saveButton.rx.tap
+            .map { [weak self] in
+                CartAddItemFormData(
+                    name: self?.mainView.nameField.text?.trimmingCharacters(
+                        in: .whitespacesAndNewlines
+                    ) ?? "",
+                    quantity: self?.mainView.quantityField.text.flatMap { Int($0) }
+                )
+            }
+            .asObservable()
+
+        let deleteTapped = mainView.deleteButton.rx.tap
+            .flatMapLatest { [weak self] _ in
+                AlertController.rx.alert(
+                    on: self,
+                    image: UIImage(named: "alertRed") ?? UIImage(),
+                    title: "항목 삭제",
+                    message: "장바구니 항목을 삭제하시겠습니까?",
+                    actions: [
+                        .cancel("취소"),
+                        .destructive("삭제")
+                    ]
+                )
+            }
+            .filter { $0.title == "삭제" }
+            .map { _ in }
+            .asObservable()
+
+        let input = CartAddItemViewModel.Input(
+            foodCategoryTapped: mainView.foodButton.rx.tap.asObservable(),
+            householdCategoryTapped: mainView.householdButton.rx.tap.asObservable(),
+            confirmTapped: confirmTapped,
+            deleteTapped: deleteTapped
+        )
+
+        let output = viewModel.transform(input)
+
+        output.selectedCategory
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] category in
+                self?.mainView.updateCategoryButtons(selected: category)
+            })
+            .disposed(by: disposeBag)
+
+        output.confirmError
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] message in
+                self?.showErrorAlert(message)
+            })
+            .disposed(by: disposeBag)
+
+        output.didConfirm
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+
+        output.didDelete
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+
+        output.error
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] message in
+                self?.showErrorAlert(message)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - Configure
+extension CartAddItemViewController {
+    func configureNavigationBar() {
+        navigationItem.title = viewModel.navigationTitle
+
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .white
+        appearance.shadowColor = .clear
+        appearance.titleTextAttributes = [
+            .font: LabelConfiguration.titleSemi18.font,
+            .foregroundColor: UIColor.gray800
+        ]
+
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
+        navigationController?.navigationBar.tintColor = .gray800
+    }
+
+    func configureInputValidation() {
+        mainView.nameField.delegate = self
+        mainView.quantityField.delegate = self
+    }
+
+    func configureMode() {
+        mainView.updateMode(isEdit: viewModel.isEditMode)
+    }
+}
+
+//MARK: - Action
+private extension CartAddItemViewController {
+    func restoreFields() {
+        guard let item = viewModel.item else { return }
+
+        mainView.nameField.text = item.name
+        mainView.quantityField.text = String(item.quantity)
+    }
+
+    func showErrorAlert(_ message: String) {
+        let alert = AlertController(
+            image: .warningIcon,
+            title: "입력 확인",
+            message: message,
+            actions: [.default("확인")]
+        )
+        present(alert, animated: true)
+    }
+}
+
+//MARK: - UITextFieldDelegate
+extension CartAddItemViewController: UITextFieldDelegate {
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        if textField == mainView.nameField {
+            return validateTextLength(
+                currentText: textField.text,
+                range: range,
+                replacementString: string,
+                maxLength: InputLimit.productName
+            )
+        }
+
+        if textField == mainView.quantityField {
+            return validateNumericInput(
+                currentText: textField.text,
+                range: range,
+                replacementString: string
+            )
+        }
+
+        return true
+    }
+
+    func validateTextLength(
+        currentText: String?,
+        range: NSRange,
+        replacementString string: String,
+        maxLength: Int
+    ) -> Bool {
+        guard let currentText else {
+            return string.count <= maxLength
+        }
+
+        let updatedText = (currentText as NSString).replacingCharacters(
+            in: range,
+            with: string
+        )
+
+        return updatedText.count <= maxLength
+    }
+
+    func validateNumericInput(
+        currentText: String?,
+        range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        if string.isEmpty {
+            return true
+        }
+
+        if string.count > 1 {
+            return false
+        }
+
+        let allowedCharacterSet = CharacterSet.decimalDigits
+        guard string.rangeOfCharacter(from: allowedCharacterSet.inverted) == nil else {
+            return false
+        }
+
+        guard let currentText else {
+            return true
+        }
+
+        let updatedText = (currentText as NSString).replacingCharacters(
+            in: range,
+            with: string
+        )
+
+        guard let value = Int(updatedText) else {
+            return false
+        }
+
+        return value <= InputLimit.quantity
+    }
+}
+
+#Preview {
+    BaseNavigationController(
+        rootViewController: CartAddItemViewController(
+            viewModel: CartAddItemViewModel(
+                coreDataManager: CoreDataManager()
+            )
+        )
+    )
+}

--- a/JaengYeo/JaengYeo/View/Cart/CartProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartProductCell.swift
@@ -195,7 +195,7 @@ private extension CartProductCell {
         upDownCountView.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(6)
             $0.centerY.equalToSuperview()
-            $0.width.equalTo(86)
+            $0.width.equalTo(100)
             $0.height.equalTo(44)
         }
     }

--- a/JaengYeo/JaengYeo/View/Cart/CartProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartProductCell.swift
@@ -1,0 +1,202 @@
+//
+//  CartProductCell.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 5/1/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxCocoa
+import RxRelay
+import RxSwift
+
+final class CartProductCell: UICollectionViewListCell {
+
+    //MARK: - Properties
+    private var disposeBag = DisposeBag()
+    private let checkButtonTapRelay = PublishRelay<Void>()
+
+    //MARK: - Components
+    private let checkButton = UIButton(type: .custom).then {
+        $0.imageView?.contentMode = .scaleAspectFit
+    }
+
+    private let contentStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 8
+        $0.alignment = .center
+        $0.distribution = .fill
+    }
+
+    private let productInfoStack = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 4
+        $0.alignment = .leading
+        $0.distribution = .fill
+    }
+
+    private let titleLabel = StyledLabel(config: .bodyMedium14).then {
+        $0.numberOfLines = 1
+        $0.lineBreakMode = .byTruncatingTail
+        $0.updateColor(.gray800)
+    }
+
+    private let categoryLabel = StyledLabel(config: .body12.updatingColor(color: .gray300)).then {
+        $0.numberOfLines = 1
+        $0.lineBreakMode = .byTruncatingTail
+    }
+
+    private let upDownCountView = ProductUpDownCountView().then {
+        $0.backgroundColor = .clear
+    }
+
+    //MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        bind()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+        titleLabel.text = nil
+        categoryLabel.text = nil
+        checkButton.isHidden = false
+        updateCheckButton(isSelected: false)
+        bind()
+    }
+}
+
+//MARK: - Public
+extension CartProductCell {
+    /// 체크 버튼 선택 이벤트
+    var checkButtonTap: Observable<Void> {
+        checkButtonTapRelay.asObservable()
+    }
+
+    /// 수량 추가 버튼 선택 이벤트
+    var addButtonTap: Observable<Void> {
+        upDownCountView.addButtonTap
+    }
+
+    /// 수량 차감 버튼 선택 이벤트
+    var deleteButtonTap: Observable<Void> {
+        upDownCountView.deleteButtonTap
+    }
+
+    /// 셀 UI 업데이트
+    func updateUI(
+        title: String,
+        category: String,
+        count: Int,
+        isSelected: Bool,
+        showsCheckBox: Bool
+    ) {
+        titleLabel.text = title
+        categoryLabel.text = category
+        upDownCountView.updateUI(count: count)
+        checkButton.isHidden = !showsCheckBox
+        updateCheckButton(isSelected: isSelected)
+    }
+
+    /// 체크 버튼 선택 바인딩
+    func bindCheckButtonTap(onNext: @escaping () -> Void) {
+        checkButtonTap
+            .bind(onNext: onNext)
+            .disposed(by: disposeBag)
+    }
+
+    /// 수량 추가 버튼 선택 바인딩
+    func bindAddButtonTap(onNext: @escaping () -> Void) {
+        addButtonTap
+            .bind(onNext: onNext)
+            .disposed(by: disposeBag)
+    }
+
+    /// 수량 차감 버튼 선택 바인딩
+    func bindDeleteButtonTap(onNext: @escaping () -> Void) {
+        deleteButtonTap
+            .bind(onNext: onNext)
+            .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - Binding
+private extension CartProductCell {
+    /// 버튼 이벤트 바인딩
+    func bind() {
+        checkButton.rx.tap
+            .bind(to: checkButtonTapRelay)
+            .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - Update
+private extension CartProductCell {
+    /// 체크 버튼 이미지 갱신
+    func updateCheckButton(isSelected: Bool) {
+        checkButton.setImage(
+            UIImage(named: isSelected ? "onIcon" : "offIcon"),
+            for: .normal
+        )
+    }
+
+}
+
+//MARK: - Configure UI
+private extension CartProductCell {
+    /// UI 설정
+    func configureUI() {
+        configureStyle()
+        configureHierarchy()
+        configureLayout()
+    }
+
+    /// 스타일 설정
+    func configureStyle() {
+        backgroundColor = .clear
+        contentView.backgroundColor = .white
+        contentView.layer.cornerRadius = 8
+        contentView.layer.borderWidth = 1
+        contentView.layer.borderColor = UIColor.gray100.cgColor
+        contentView.clipsToBounds = true
+    }
+
+    /// 계층 설정
+    func configureHierarchy() {
+        contentView.addSubview(contentStack)
+        contentView.addSubview(upDownCountView)
+
+        contentStack.addArrangedSubview(checkButton)
+        contentStack.addArrangedSubview(productInfoStack)
+        productInfoStack.addArrangedSubview(titleLabel)
+        productInfoStack.addArrangedSubview(categoryLabel)
+    }
+
+    /// 레이아웃 설정
+    func configureLayout() {
+        checkButton.snp.makeConstraints {
+            $0.size.equalTo(24)
+        }
+
+        contentStack.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(16)
+            $0.centerY.equalToSuperview()
+            $0.trailing.lessThanOrEqualTo(upDownCountView.snp.leading).offset(-8)
+        }
+
+        upDownCountView.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(6)
+            $0.centerY.equalToSuperview()
+            $0.width.equalTo(86)
+            $0.height.equalTo(44)
+        }
+    }
+}

--- a/JaengYeo/JaengYeo/View/Cart/CartView.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartView.swift
@@ -1,0 +1,343 @@
+//
+//  CartView.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 5/1/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxCocoa
+import RxRelay
+import RxSwift
+
+final class CartView: UIView {
+
+    //MARK: - Enum
+    enum Section {
+        case main
+    }
+
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private let itemSelectedRelay = PublishRelay<CartItem>()
+    private let itemDeletedRelay = PublishRelay<CartItem>()
+    private let itemQuantityIncreasedRelay = PublishRelay<CartItem>()
+    private let itemQuantityDecreasedRelay = PublishRelay<CartItem>()
+    private let swipeDeleteRelay = PublishRelay<IndexPath>()
+    private lazy var dataSource = configureDataSource()
+
+    //MARK: - Components
+    private let infoView = UIView().then {
+        $0.backgroundColor = .gray50
+    }
+
+    private let totalCountLabel = StyledLabel(
+        config: LabelConfiguration.body12.updatingColor(color: .gray500)
+    ).then {
+        $0.text = "총 0개"
+    }
+
+    private let sortedButton = UIButton(configuration: .plain()).then {
+        var config = UIButton.Configuration.plain()
+        var title = AttributedString("최근 등록순")
+        title.font = .systemFont(ofSize: 12, weight: .regular)
+        title.foregroundColor = .gray800
+
+        let symbolConfig = UIImage.SymbolConfiguration(
+            pointSize: 10,
+            weight: .medium
+        )
+
+        config.attributedTitle = title
+        config.image = UIImage(
+            systemName: "chevron.down",
+            withConfiguration: symbolConfig
+        )
+        config.baseForegroundColor = .gray800
+        config.imagePlacement = .trailing
+        config.imagePadding = 1
+        config.contentInsets = .zero
+        $0.configuration = config
+    }
+
+    private lazy var collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: createLayout()
+    ).then {
+        $0.backgroundColor = .gray50
+        $0.showsVerticalScrollIndicator = false
+    }
+
+    private let confirmButton = StyledButton(
+        title: "구매 확정",
+        titleConfiguration: .defaultTitle,
+        appearanceConfiguration: .defaultAppearance
+    )
+
+    //MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        bind()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+//MARK: - Public
+extension CartView {
+    /// 장바구니 컬렉션 뷰
+    var cartCollectionView: UICollectionView {
+        collectionView
+    }
+
+    /// 상품 셀 선택 이벤트
+    var itemSelected: Observable<CartItem> {
+        itemSelectedRelay.asObservable()
+    }
+
+    /// 상품 삭제 이벤트
+    var itemDeleted: Observable<CartItem> {
+        itemDeletedRelay.asObservable()
+    }
+
+    /// 상품 수량 추가 이벤트
+    var itemQuantityIncreased: Observable<CartItem> {
+        itemQuantityIncreasedRelay.asObservable()
+    }
+
+    /// 상품 수량 차감 이벤트
+    var itemQuantityDecreased: Observable<CartItem> {
+        itemQuantityDecreasedRelay.asObservable()
+    }
+
+    /// 구매 확정 버튼 선택 이벤트
+    var confirmButtonTap: Observable<Void> {
+        confirmButton.rx.tap.asObservable()
+    }
+
+    /// 정렬 메뉴 설정
+    func configureSortMenu(
+        options: [String],
+        onSelect: @escaping (String) -> Void
+    ) {
+        sortedButton.showsMenuAsPrimaryAction = true
+        sortedButton.menu = UIMenu(
+            children: options.map { option in
+                UIAction(title: option) { _ in
+                    onSelect(option)
+                }
+            }
+        )
+    }
+
+    /// 정렬 타이틀 변경
+    func updateSortTitle(_ title: String) {
+        var config = sortedButton.configuration ?? .plain()
+        var attributedTitle = AttributedString(title)
+        attributedTitle.font = .systemFont(ofSize: 12, weight: .regular)
+        attributedTitle.foregroundColor = .gray800
+        config.attributedTitle = attributedTitle
+        sortedButton.configuration = config
+    }
+
+    /// 스냅샷 적용
+    func applySnapshot(with items: [CartItem]) {
+        totalCountLabel.text = "총 \(items.count)개"
+
+        var snapshot = NSDiffableDataSourceSnapshot<Section, CartItem>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(items, toSection: .main)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+}
+
+
+//MARK: - Binding
+private extension CartView {
+    func bind() {
+        collectionView.rx.itemSelected
+            .do(onNext: { [weak self] indexPath in
+                self?.collectionView.deselectItem(
+                    at: indexPath,
+                    animated: false
+                )
+            })
+            .compactMap { [weak self] indexPath in
+                self?.dataSource.itemIdentifier(for: indexPath)
+            }
+            .bind(to: itemSelectedRelay)
+            .disposed(by: disposeBag)
+
+        swipeDeleteRelay
+            .compactMap { [weak self] indexPath in
+                self?.dataSource.itemIdentifier(for: indexPath)
+            }
+            .bind(to: itemDeletedRelay)
+            .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - DataSource
+private extension CartView {
+    /// 데이터소스 설정
+    func configureDataSource() -> UICollectionViewDiffableDataSource<
+        Section,
+        CartItem
+    > {
+        let cellRegistration = UICollectionView.CellRegistration<
+            CartProductCell,
+            CartItem
+        > { [weak self] cell, _, item in
+            guard let self else { return }
+
+            cell.updateUI(
+                title: item.name,
+                category: item.mainCategory,
+                count: 1,
+                isSelected: false,
+                showsCheckBox: false
+            )
+
+            cell.bindAddButtonTap { [weak self] in
+                self?.itemQuantityIncreasedRelay.accept(item)
+            }
+
+            cell.bindDeleteButtonTap { [weak self] in
+                self?.itemQuantityDecreasedRelay.accept(item)
+            }
+        }
+
+        return UICollectionViewDiffableDataSource<Section, CartItem>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, item in
+            collectionView.dequeueConfiguredReusableCell(
+                using: cellRegistration,
+                for: indexPath,
+                item: item
+            )
+        }
+    }
+}
+
+//MARK: - Compositional Layout
+private extension CartView {
+    /// 컬렉션 뷰 레이아웃 생성
+    func createLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { _, environment in
+            var configuration = UICollectionLayoutListConfiguration(
+                appearance: .plain
+            )
+            configuration.showsSeparators = false
+            configuration.backgroundColor = .clear
+            configuration.trailingSwipeActionsConfigurationProvider = { indexPath in
+                let deleteAction = UIContextualAction(
+                    style: .destructive,
+                    title: nil
+                ) { [weak self] _, _, completion in
+                    self?.swipeDeleteRelay.accept(indexPath)
+                    completion(true)
+                }
+                deleteAction.image = UIImage(systemName: "trash")
+
+                let configuration = UISwipeActionsConfiguration(
+                    actions: [deleteAction]
+                )
+                configuration.performsFirstActionWithFullSwipe = false
+                return configuration
+            }
+
+            let section = NSCollectionLayoutSection.list(
+                using: configuration,
+                layoutEnvironment: environment
+            )
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top: 0,
+                leading: 16,
+                bottom: 0,
+                trailing: 16
+            )
+            section.interGroupSpacing = 8
+            return section
+        }
+    }
+}
+
+//MARK: - Configure UI
+private extension CartView {
+    /// UI 설정
+    func configureUI() {
+        backgroundColor = .gray50
+
+        addSubview(infoView)
+        addSubview(collectionView)
+        addSubview(confirmButton)
+
+        infoView.addSubview(totalCountLabel)
+        infoView.addSubview(sortedButton)
+
+        infoView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(40)
+        }
+
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(infoView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(confirmButton.snp.top).inset(16)
+        }
+
+        confirmButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(44)
+        }
+
+        totalCountLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(16)
+        }
+
+        sortedButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(16)
+        }
+    }
+}
+
+
+
+#Preview {
+    let viewController = UIViewController()
+    let cartView = CartView()
+
+    viewController.view.addSubview(cartView)
+    cartView.snp.makeConstraints {
+        $0.edges.equalToSuperview()
+    }
+
+    cartView.applySnapshot(
+        with: [
+            CartItem(
+                id: UUID(),
+                referenceId: nil,
+                name: "토마토",
+                mainCategory: "식재료",
+                createdAt: Date()
+            ),
+            CartItem(
+                id: UUID(),
+                referenceId: nil,
+                name: "바나나",
+                mainCategory: "식재료",
+                createdAt: Date()
+            )
+        ]
+    )
+
+    return viewController
+}

--- a/JaengYeo/JaengYeo/View/Cart/CartView.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartView.swift
@@ -198,7 +198,7 @@ private extension CartView {
             cell.updateUI(
                 title: item.name,
                 category: item.mainCategory,
-                count: 1,
+                count: item.quantity,
                 isSelected: false,
                 showsCheckBox: false
             )
@@ -327,6 +327,7 @@ private extension CartView {
                 referenceId: nil,
                 name: "토마토",
                 mainCategory: "식재료",
+                quantity: 8,
                 createdAt: Date()
             ),
             CartItem(
@@ -334,6 +335,7 @@ private extension CartView {
                 referenceId: nil,
                 name: "바나나",
                 mainCategory: "식재료",
+                quantity: 3,
                 createdAt: Date()
             )
         ]

--- a/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
@@ -1,0 +1,72 @@
+//
+//  CartViewController.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 4/28/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+import RxCocoa
+
+final class CartViewController: BaseViewController {
+
+    //MARK: - ViewModel
+    private let viewModel: CartViewModel?
+    
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    
+    
+    //MARK: - Init
+    init(viewModel: CartViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        overrideUserInterfaceStyle = .light
+    }
+
+    init() {
+        self.viewModel = nil
+        super.init(nibName: nil, bundle: nil)
+        overrideUserInterfaceStyle = .light
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        bind()
+    }
+}
+
+//MARK: - Binding
+private extension CartViewController {
+    func bind() {
+        guard let viewModel else { return }
+
+        let input = CartViewModel.Input(
+            viewDidLoad: Observable.just(())
+        )
+        
+        _ = viewModel.transform(input)
+    }
+}
+
+//MARK: - Configure UI
+private extension CartViewController {
+    func configureUI() {
+        view.backgroundColor = .white
+        navigationItem.title = "장바구니"
+    }
+}
+
+#Preview {
+    BaseNavigationController(
+        rootViewController: CartViewController()
+    )
+}

--- a/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
@@ -7,9 +7,12 @@
 
 import UIKit
 import SnapKit
-import Then
 import RxSwift
 import RxCocoa
+
+protocol CartViewControllerDelegate: AnyObject {
+    func didTapCartAddButton()
+}
 
 final class CartViewController: BaseViewController {
 
@@ -18,27 +21,32 @@ final class CartViewController: BaseViewController {
     
     //MARK: - Properties
     private let disposeBag = DisposeBag()
-    
+    weak var delegate: CartViewControllerDelegate?
+
+    //MARK: - Components
+    private let cartView = CartView()
+
+    private let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
+
     
     //MARK: - Init
     init(viewModel: CartViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        overrideUserInterfaceStyle = .light
     }
 
     init() {
         self.viewModel = nil
         super.init(nibName: nil, bundle: nil)
-        overrideUserInterfaceStyle = .light
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNavigationBar()
         configureUI()
         bind()
     }
@@ -47,21 +55,60 @@ final class CartViewController: BaseViewController {
 //MARK: - Binding
 private extension CartViewController {
     func bind() {
+        addButton.rx.tap
+            .bind(onNext: { [weak self] in
+                self?.delegate?.didTapCartAddButton()
+            })
+            .disposed(by: disposeBag)
+
         guard let viewModel else { return }
 
         let input = CartViewModel.Input(
-            viewDidLoad: Observable.just(())
+            viewDidLoad: Observable.just(()),
+            itemDeleted: cartView.itemDeleted,
+            itemQuantityIncreased: cartView.itemQuantityIncreased,
+            itemQuantityDecreased: cartView.itemQuantityDecreased
         )
         
-        _ = viewModel.transform(input)
+        let output = viewModel.transform(input)
+
+        output.cartItems
+            .bind(onNext: { [weak self] items in
+                self?.cartView.applySnapshot(with: items)
+            })
+            .disposed(by: disposeBag)
     }
 }
 
 //MARK: - Configure UI
 private extension CartViewController {
+    func configureNavigationBar() {
+        navigationItem.title = "구매 예정 목록"
+
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .white
+        appearance.shadowColor = .clear
+        appearance.titleTextAttributes = [
+            .font: LabelConfiguration.titleSemi18.font,
+            .foregroundColor: UIColor.gray800
+        ]
+
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
+        navigationController?.navigationBar.tintColor = .gray800
+
+        navigationItem.rightBarButtonItem = addButton
+    }
+    
     func configureUI() {
-        view.backgroundColor = .white
-        navigationItem.title = "장바구니"
+        view.addSubview(cartView)
+
+        cartView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
     }
 }
 

--- a/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
@@ -11,7 +11,9 @@ import RxSwift
 import RxCocoa
 
 protocol CartViewControllerDelegate: AnyObject {
-    func didTapCartAddButton()
+    func didTapExistingProductButton()
+    func didTapNewProductButton()
+    func didSelectCartItem(_ item: CartItem)
 }
 
 final class CartViewController: BaseViewController {
@@ -21,6 +23,7 @@ final class CartViewController: BaseViewController {
     
     //MARK: - Properties
     private let disposeBag = DisposeBag()
+    private let viewWillAppearRelay = PublishRelay<Void>()
     weak var delegate: CartViewControllerDelegate?
 
     //MARK: - Components
@@ -50,22 +53,39 @@ final class CartViewController: BaseViewController {
         configureUI()
         bind()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewWillAppearRelay.accept(())
+    }
 }
 
 //MARK: - Binding
 private extension CartViewController {
     func bind() {
-        addButton.rx.tap
-            .bind(onNext: { [weak self] in
-                self?.delegate?.didTapCartAddButton()
-            })
-            .disposed(by: disposeBag)
-
         guard let viewModel else { return }
+
+        let itemDeleted = cartView.itemDeleted
+            .flatMapLatest { [weak self] item in
+                AlertController.rx.alert(
+                    on: self,
+                    image: UIImage(named: "alertRed") ?? UIImage(),
+                    title: "항목 삭제",
+                    message: "장바구니 항목을 삭제하시겠습니까?",
+                    actions: [
+                        .cancel("취소"),
+                        .destructive("삭제")
+                    ]
+                )
+                .filter { $0.title == "삭제" }
+                .map { _ in item }
+            }
+            .asObservable()
 
         let input = CartViewModel.Input(
             viewDidLoad: Observable.just(()),
-            itemDeleted: cartView.itemDeleted,
+            viewWillAppear: viewWillAppearRelay.asObservable(),
+            itemDeleted: itemDeleted,
             itemQuantityIncreased: cartView.itemQuantityIncreased,
             itemQuantityDecreased: cartView.itemQuantityDecreased
         )
@@ -75,6 +95,12 @@ private extension CartViewController {
         output.cartItems
             .bind(onNext: { [weak self] items in
                 self?.cartView.applySnapshot(with: items)
+            })
+            .disposed(by: disposeBag)
+
+        cartView.itemSelected
+            .bind(onNext: { [weak self] item in
+                self?.delegate?.didSelectCartItem(item)
             })
             .disposed(by: disposeBag)
     }
@@ -99,6 +125,7 @@ private extension CartViewController {
         navigationController?.navigationBar.compactAppearance = appearance
         navigationController?.navigationBar.tintColor = .gray800
 
+        configureAddMenu()
         navigationItem.rightBarButtonItem = addButton
     }
     
@@ -109,6 +136,23 @@ private extension CartViewController {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.bottom.equalToSuperview()
         }
+    }
+
+    func configureAddMenu() {
+        let existingProductAction = UIAction(title: "기존제품") { [weak self] _ in
+            self?.delegate?.didTapExistingProductButton()
+        }
+
+        let newProductAction = UIAction(title: "신규등록") { [weak self] _ in
+            self?.delegate?.didTapNewProductButton()
+        }
+
+        addButton.menu = UIMenu(
+            children: [
+                existingProductAction,
+                newProductAction
+            ]
+        )
     }
 }
 

--- a/JaengYeo/JaengYeo/View/Common/AlertController.swift
+++ b/JaengYeo/JaengYeo/View/Common/AlertController.swift
@@ -132,6 +132,7 @@ extension AlertController {
         $0.text = message
         $0.textColor = .gray500
         $0.numberOfLines = 0
+        $0.textAlignment = .center
       }
       addSubview(messageLabel)
       messageLabel.snp.makeConstraints {

--- a/JaengYeo/JaengYeo/View/MainController.swift
+++ b/JaengYeo/JaengYeo/View/MainController.swift
@@ -12,13 +12,15 @@ class MainController: UITabBarController {
     init(
         homeNavigationController: UINavigationController,
         registerNavigationController: UINavigationController,
-        stockNavigationController: UINavigationController
+        stockNavigationController: UINavigationController,
+        cartNavigationController: UINavigationController
     ) {
         super.init(nibName: nil, bundle: nil)
         viewControllers = [
             homeNavigationController,
             registerNavigationController,
-            stockNavigationController
+            stockNavigationController,
+            cartNavigationController
         ]
     }
     

--- a/JaengYeo/JaengYeo/View/MainController.swift
+++ b/JaengYeo/JaengYeo/View/MainController.swift
@@ -9,6 +9,9 @@ import UIKit
 
 class MainController: UITabBarController {
     
+    //MARK: - Properties
+    var onCartTabSelected: (() -> Void)?
+    
     init(
         homeNavigationController: UINavigationController,
         registerNavigationController: UINavigationController,
@@ -31,6 +34,7 @@ class MainController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
+        delegate = self
         setupTabBar()
     }
 }
@@ -39,5 +43,23 @@ extension MainController {
     private func setupTabBar() {
         //TODO: TabBar 색상 및 스타일 설정 필요
         tabBar.tintColor = .gray800
+    }
+}
+
+extension MainController: UITabBarControllerDelegate {
+    func tabBarController(
+        _ tabBarController: UITabBarController,
+        shouldSelect viewController: UIViewController
+    ) -> Bool {
+        guard let index = viewControllers?.firstIndex(of: viewController) else {
+            return true
+        }
+
+        if index == 3 {
+            onCartTabSelected?()
+            return false
+        }
+
+        return true
     }
 }

--- a/JaengYeo/JaengYeo/ViewModel/Cart/CartAddItemViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Cart/CartAddItemViewModel.swift
@@ -1,0 +1,174 @@
+//
+//  CartAddItemViewModel.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 5/3/26.
+//
+
+import Foundation
+import RxCocoa
+import RxRelay
+import RxSwift
+
+final class CartAddItemViewModel: ViewModelProtocol {
+
+    //MARK: - Properties
+    let item: CartItem?
+    private let disposeBag = DisposeBag()
+    private let coreDataManager: CoreDataManagerProtocol
+    private let selectedMainCategorySubject: BehaviorSubject<MainCategory?>
+
+    var navigationTitle: String {
+        item == nil ? "신규 등록" : "수정"
+    }
+
+    var isEditMode: Bool {
+        item != nil
+    }
+
+    struct Input {
+        /// 식재료 버튼 탭 이벤트
+        let foodCategoryTapped: Observable<Void>
+        /// 생활용품 버튼 탭 이벤트
+        let householdCategoryTapped: Observable<Void>
+        /// 저장 버튼 탭 이벤트
+        let confirmTapped: Observable<CartAddItemFormData>
+        /// 삭제 버튼 탭 이벤트
+        let deleteTapped: Observable<Void>
+    }
+
+    struct Output {
+        /// 선택된 대분류
+        let selectedCategory: Observable<MainCategory?>
+        /// 필수 입력 에러
+        let confirmError: Observable<String>
+        /// 저장 완료 이벤트
+        let didConfirm: Observable<Void>
+        /// 삭제 완료 이벤트
+        let didDelete: Observable<Void>
+        /// 에러 메시지
+        let error: Observable<String>
+    }
+
+    //MARK: - Init
+    init(coreDataManager: CoreDataManagerProtocol, item: CartItem? = nil) {
+        self.coreDataManager = coreDataManager
+        self.item = item
+
+        let initialCategory = item.flatMap {
+            MainCategory(rawValue: $0.mainCategory)
+        }
+        self.selectedMainCategorySubject = BehaviorSubject(
+            value: initialCategory
+        )
+    }
+
+    func transform(_ input: Input) -> Output {
+        let confirmErrorSubject = PublishSubject<String>()
+        let didConfirmSubject = PublishSubject<Void>()
+        let didDeleteSubject = PublishSubject<Void>()
+        let errorSubject = PublishSubject<String>()
+
+        input.foodCategoryTapped
+            .bind(onNext: { [weak self] in
+                self?.selectedMainCategorySubject.onNext(.foodstuff)
+            })
+            .disposed(by: disposeBag)
+
+        input.householdCategoryTapped
+            .bind(onNext: { [weak self] in
+                self?.selectedMainCategorySubject.onNext(.household)
+            })
+            .disposed(by: disposeBag)
+
+        input.confirmTapped
+            .withLatestFrom(selectedMainCategorySubject) { formData, category in
+                (formData, category)
+            }
+            .bind(onNext: { [weak self] formData, category in
+                guard let self else { return }
+                guard let item = makeCartItem(
+                    formData: formData,
+                    mainCategory: category,
+                    confirmErrorSubject: confirmErrorSubject
+                ) else { return }
+
+                do {
+                    if self.item == nil {
+                        try coreDataManager.createCartItem(item.toPayload)
+                    } else {
+                        try coreDataManager.updateCartItem(item.toPayload)
+                    }
+                    didConfirmSubject.onNext(())
+                } catch {
+                    errorSubject.onNext("장바구니 항목을 저장하는 중 오류가 발생했습니다.")
+                }
+            })
+            .disposed(by: disposeBag)
+
+        input.deleteTapped
+            .bind(onNext: { [weak self] in
+                guard let self, let item else { return }
+
+                do {
+                    try coreDataManager.deleteCartItem(id: item.id)
+                    didDeleteSubject.onNext(())
+                } catch {
+                    errorSubject.onNext("장바구니 항목을 삭제하는 중 오류가 발생했습니다.")
+                }
+            })
+            .disposed(by: disposeBag)
+
+        return Output(
+            selectedCategory: selectedMainCategorySubject.asObservable(),
+            confirmError: confirmErrorSubject.asObservable(),
+            didConfirm: didConfirmSubject.asObservable(),
+            didDelete: didDeleteSubject.asObservable(),
+            error: errorSubject.asObservable()
+        )
+    }
+}
+
+//MARK: - Validate
+private extension CartAddItemViewModel {
+    func makeCartItem(
+        formData: CartAddItemFormData,
+        mainCategory: MainCategory?,
+        confirmErrorSubject: PublishSubject<String>
+    ) -> CartItem? {
+        guard formData.name.isEmpty == false else {
+            confirmErrorSubject.onNext("이름을 입력해주세요.")
+            return nil
+        }
+
+        guard let quantity = formData.quantity else {
+            confirmErrorSubject.onNext("수량을 입력해주세요.")
+            return nil
+        }
+
+        guard quantity != 0 else {
+            confirmErrorSubject.onNext("수량은 최소 1개 이상이어야 합니다.")
+            return nil
+        }
+
+        guard let mainCategory else {
+            confirmErrorSubject.onNext("메인 카테고리를 선택해주세요.")
+            return nil
+        }
+
+        return CartItem(
+            id: item?.id ?? UUID(),
+            referenceId: item?.referenceId,
+            name: formData.name,
+            mainCategory: mainCategory.rawValue,
+            quantity: quantity,
+            createdAt: item?.createdAt ?? Date()
+        )
+    }
+}
+
+//MARK: - FormData
+struct CartAddItemFormData {
+    let name: String
+    let quantity: Int?
+}

--- a/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  CartViewModel.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 4/28/26.
+//
+
+import Foundation
+import RxSwift
+import RxRelay
+
+final class CartViewModel: ViewModelProtocol {
+
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private var cartItemObservationDisposeBag = DisposeBag()
+    private let coreDataManager: CoreDataManagerProtocol
+    private let cartItemsRelay = BehaviorRelay<[CartItem]>(value: [])
+    
+    struct Input {
+        /// 화면 로드 이벤트
+        let viewDidLoad: Observable<Void>
+    }
+    
+    struct Output {
+        /// 장바구니 아이템 목록
+        let cartItems: Observable<[CartItem]>
+        /// 장바구니 비어있는지 여부
+        let isEmpty: Observable<Bool>
+        /// 장바구니 아이템 개수
+        let totalCountText: Observable<Int>
+    }
+    
+    func transform(_ input: Input) -> Output {
+        input.viewDidLoad
+            .subscribe(onNext: { [weak self] in
+                self?.bindCartItems()
+            })
+            .disposed(by: disposeBag)
+        
+        return Output(
+            cartItems: cartItemsRelay.asObservable(),
+            isEmpty: cartItemsRelay
+                .map { $0.isEmpty }
+                .asObservable(),
+            totalCountText: cartItemsRelay
+                .map { $0.count }
+                .asObservable()
+        )
+    }
+    
+    //MARK: - Init
+    init(coreDataManager: CoreDataManagerProtocol) {
+        self.coreDataManager = coreDataManager
+    }
+}
+
+//MARK: - Binding
+private extension CartViewModel {
+    /// 장바구니 아이템 변경 관찰
+    func bindCartItems() {
+        cartItemObservationDisposeBag = DisposeBag()
+        
+        coreDataManager.observeCartItems(
+            sortDescriptors: [
+                NSSortDescriptor(
+                    key: "createDate",
+                    ascending: false
+                )
+            ]
+        )
+        .map { $0.map { $0.toDomain } }
+        .bind(to: cartItemsRelay)
+        .disposed(by: cartItemObservationDisposeBag)
+    }
+}

--- a/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
@@ -20,6 +20,12 @@ final class CartViewModel: ViewModelProtocol {
     struct Input {
         /// 화면 로드 이벤트
         let viewDidLoad: Observable<Void>
+        /// 장바구니 아이템 삭제 이벤트
+        let itemDeleted: Observable<CartItem>
+        /// 장바구니 아이템 수량 증가 이벤트
+        let itemQuantityIncreased: Observable<CartItem>
+        /// 장바구니 아이템 수량 감소 이벤트
+        let itemQuantityDecreased: Observable<CartItem>
     }
     
     struct Output {
@@ -35,6 +41,24 @@ final class CartViewModel: ViewModelProtocol {
         input.viewDidLoad
             .subscribe(onNext: { [weak self] in
                 self?.bindCartItems()
+            })
+            .disposed(by: disposeBag)
+
+        input.itemDeleted
+            .subscribe(onNext: { [weak self] item in
+                try? self?.coreDataManager.deleteCartItem(id: item.id)
+            })
+            .disposed(by: disposeBag)
+
+        input.itemQuantityIncreased
+            .subscribe(onNext: { [weak self] item in
+                self?.updateCartItem(item.increased())
+            })
+            .disposed(by: disposeBag)
+
+        input.itemQuantityDecreased
+            .subscribe(onNext: { [weak self] item in
+                self?.updateCartItem(item.decreased())
             })
             .disposed(by: disposeBag)
         
@@ -72,5 +96,10 @@ private extension CartViewModel {
         .map { $0.map { $0.toDomain } }
         .bind(to: cartItemsRelay)
         .disposed(by: cartItemObservationDisposeBag)
+    }
+
+    /// 장바구니 아이템 갱신
+    func updateCartItem(_ item: CartItem) {
+        try? coreDataManager.updateCartItem(item.toPayload)
     }
 }

--- a/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
@@ -20,6 +20,8 @@ final class CartViewModel: ViewModelProtocol {
     struct Input {
         /// 화면 로드 이벤트
         let viewDidLoad: Observable<Void>
+        /// 화면 재진입 이벤트
+        let viewWillAppear: Observable<Void>
         /// 장바구니 아이템 삭제 이벤트
         let itemDeleted: Observable<CartItem>
         /// 장바구니 아이템 수량 증가 이벤트
@@ -44,21 +46,31 @@ final class CartViewModel: ViewModelProtocol {
             })
             .disposed(by: disposeBag)
 
+        input.viewWillAppear
+            .subscribe(onNext: { [weak self] in
+                self?.fetchCartItems()
+            })
+            .disposed(by: disposeBag)
+
         input.itemDeleted
             .subscribe(onNext: { [weak self] item in
-                try? self?.coreDataManager.deleteCartItem(id: item.id)
+                self?.deleteCartItem(item)
             })
             .disposed(by: disposeBag)
 
         input.itemQuantityIncreased
             .subscribe(onNext: { [weak self] item in
-                self?.updateCartItem(item.increased())
+                self?.updateCartItem(id: item.id) {
+                    $0.increased()
+                }
             })
             .disposed(by: disposeBag)
 
         input.itemQuantityDecreased
             .subscribe(onNext: { [weak self] item in
-                self?.updateCartItem(item.decreased())
+                self?.updateCartItem(id: item.id) {
+                    $0.decreased()
+                }
             })
             .disposed(by: disposeBag)
         
@@ -99,7 +111,43 @@ private extension CartViewModel {
     }
 
     /// 장바구니 아이템 갱신
-    func updateCartItem(_ item: CartItem) {
-        try? coreDataManager.updateCartItem(item.toPayload)
+    func updateCartItem(
+        id: UUID,
+        transform: (CartItem) -> CartItem
+    ) {
+        var items = cartItemsRelay.value
+
+        guard let index = items.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        let updatedItem = transform(items[index])
+        items[index] = updatedItem
+        cartItemsRelay.accept(items)
+
+        try? coreDataManager.updateCartItem(updatedItem.toPayload)
+    }
+
+    /// 장바구니 아이템 삭제
+    func deleteCartItem(_ item: CartItem) {
+        do {
+            try coreDataManager.deleteCartItem(id: item.id)
+
+            let items = cartItemsRelay.value.filter {
+                $0.id != item.id
+            }
+            cartItemsRelay.accept(items)
+        } catch {
+            return
+        }
+    }
+
+    /// 장바구니 목록 재조회
+    func fetchCartItems() {
+        guard let items = try? coreDataManager.fetchAllCartItems() else {
+            return
+        }
+
+        cartItemsRelay.accept(items.map { $0.toDomain() })
     }
 }

--- a/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
@@ -148,6 +148,6 @@ private extension CartViewModel {
             return
         }
 
-        cartItemsRelay.accept(items.map { $0.toDomain() })
+        cartItemsRelay.accept(items.map { $0.toDomain })
     }
 }


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #149 , #150 

🛠 작업 내용 (What I did)
- 장바구니 목록 화면을 신규로 구성하고, 탭바에서 진입 시 push 방식으로 화면 전환되도록 연결
- 장바구니 상품 셀 선택 시 수정 화면으로, 우상단 + 버튼 탭 시 신규 등록 / 기존 제품 추가 메뉴로 분기되도록 구현
- CoreData 기반으로 장바구니 아이템 CRUD 및 수량 증감을 처리하고 목록에 실시간 반영

💻 구현 상세 (Implementation Details)
- CartViewModel: CoreData 변경 구독 및 수동 fetch로 목록 관리, 수량 증감 처리
- CartViewController: 삭제 알럿 연결 및 Delegate로 Coordinator에 화면 전환 위임
- CartView: CompositionalLayout + DiffableDataSource 구성, 스와이프 삭제 지원
- CartProductCell: prepareForReuse 시 disposeBag 교체로 구독 초기화
- CartAddItemViewModel: 신규/수정 모드 분기, 유효성 검사 후 CoreData 저장
- CartAddItemViewController / CartAddItemView: 입력 길이 제한 검증, 키보드 대응, 수정 모드 시 레이아웃 전환
- CartCoordinator: 선택된 탭의 네비게이션 컨트롤러를 전달받아 push, 중복 push 방지