### PR TITLE
[장바구니] 재고 화면에서 장바구니 담기 기능 구현 #151

### DIFF
--- a/JaengYeo/JaengYeo/Application/CartCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/CartCoordinator.swift
@@ -48,8 +48,28 @@ extension CartCoordinator {
     }
 }
 
+extension CartCoordinator: StockSearchViewControllerDelegate {
+    func stockSearchViewController(
+        _ viewController: StockSearchViewController,
+        didSelectProduct productID: UUID
+    ) {
+        let viewController = ProductDetailViewController(
+            viewModel: ProductDetailViewModel(
+                productID: productID,
+                coreDataManager: coreDataManager
+            )
+        )
+        currentNavigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
 extension CartCoordinator: CartViewControllerDelegate {
     func didTapExistingProductButton() {
+        let viewController = StockSearchViewController(
+            viewModel: StockSearchViewModel(coreDataManager: coreDataManager)
+        )
+        viewController.delegate = self
+        currentNavigationController?.pushViewController(viewController, animated: true)
     }
 
     func didTapNewProductButton() {

--- a/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
@@ -139,7 +139,7 @@ private extension CartViewController {
     }
 
     func configureAddMenu() {
-        let existingProductAction = UIAction(title: "기존제품") { [weak self] _ in
+        let existingProductAction = UIAction(title: "냠ㄴ") { [weak self] _ in
             self?.delegate?.didTapExistingProductButton()
         }
 

--- a/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
@@ -139,7 +139,7 @@ private extension CartViewController {
     }
 
     func configureAddMenu() {
-        let existingProductAction = UIAction(title: "냠ㄴ") { [weak self] _ in
+        let existingProductAction = UIAction(title: "기존제품") { [weak self] _ in
             self?.delegate?.didTapExistingProductButton()
         }
 

--- a/JaengYeo/JaengYeo/View/Common/ProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Common/ProductCell.swift
@@ -22,6 +22,8 @@ enum ProductCellType {
     case registType
     /// 홈디자인
     case homeType
+    /// 검색 결과 디자인
+    case searchType
     /// 미분류 상품 디자인
     case unclassifiedType
 }
@@ -54,7 +56,7 @@ final class ProductCell: UICollectionViewListCell{
                 productCountView.isHidden = true
                 upDownCountView.isHidden = true
             
-            case .homeType:
+            case .homeType, .searchType:
                 productSubDescriptionStack.isHidden = false
                 productCountView.isHidden = true
                 upDownCountView.isHidden = false
@@ -62,7 +64,7 @@ final class ProductCell: UICollectionViewListCell{
                 config.strokeColor = UIColor.gray100
                 config.strokeWidth = 1
                 backgroundConfiguration = config
-            
+
             case .unclassifiedType:
                 productSubDescriptionStack.isHidden = true
                 productCountView.isHidden = true
@@ -83,8 +85,9 @@ final class ProductCell: UICollectionViewListCell{
     }
     
     /// 아이템 타이틀
-    private let productTitleLabel = StyledLabel(config: .bodyMedium14).then {
-        $0.text = ""
+    private let productTitleLabel = UILabel().then {
+        $0.font = LabelConfiguration.bodyMedium14.font
+        $0.textColor = .gray800
         $0.numberOfLines = 1
         $0.lineBreakMode = .byTruncatingTail
     }
@@ -195,22 +198,57 @@ extension ProductCell {
         subdescriptions: [String]?,
         count: Int?,
         image: UIImage?,
-        highlightFirst: Bool = false
+        highlightFirst: Bool = false,
+        keyword: String? = nil
     ) {
         cellType = type
-        productTitleLabel.text = title
         productTitleLabel.numberOfLines = 1
         productTitleLabel.lineBreakMode = .byTruncatingTail
         productImageView.image = image ?? UIImage(named: "imageSelectIcon")
         productImageView.backgroundColor = .clear
 
-        updateDescriptionStack(
-            stackView: productDescriptionStack,
-            freshness: freshness,
-            texts: descriptions,
-            highlightFirst: highlightFirst
-        )
-        
+        if let keyword, !keyword.isEmpty,
+           title.lowercased().contains(keyword.lowercased()) {
+            productTitleLabel.attributedText = makeHighlightedAttributedString(
+                title,
+                keyword: keyword,
+                baseFont: LabelConfiguration.bodyMedium14.font,
+                baseColor: .gray800
+            )
+        } else {
+            productTitleLabel.attributedText = NSAttributedString(
+                string: title,
+                attributes: [
+                    .font: LabelConfiguration.bodyMedium14.font,
+                    .foregroundColor: UIColor.gray800
+                ]
+            )
+        }
+
+        if type == .searchType {
+            let freshnessText: String? = freshness.map { f in
+                if f > 0 { return "\(f)일 남음" }
+                else if f == 0 { return "오늘 만료" }
+                else { return "유통기한 만료" }
+            }
+            let resolvedDescriptions = [freshnessText].compactMap { $0 } + (descriptions ?? [])
+            updateDescriptionStack(
+                stackView: productDescriptionStack,
+                freshness: nil,
+                texts: resolvedDescriptions,
+                highlightFirst: highlightFirst,
+                keyword: keyword
+            )
+        } else {
+            updateDescriptionStack(
+                stackView: productDescriptionStack,
+                freshness: freshness,
+                texts: descriptions,
+                highlightFirst: highlightFirst,
+                keyword: keyword
+            )
+        }
+
         if usesUpDownCountView {
             productCountView.isHidden = true
             upDownCountView.isHidden = false
@@ -226,16 +264,16 @@ extension ProductCell {
                 productCountView.isHidden = true
                 upDownCountView.isHidden = true
 
-            case .defaultType, .homeType:
+            case .defaultType, .homeType, .searchType:
                 break
             }
         }
         
-        if cellType == .detailType || cellType == .registType || cellType == .homeType {
+        if cellType == .detailType || cellType == .registType || cellType == .homeType || cellType == .searchType {
             updateDescriptionStack(
                 stackView: productSubDescriptionStack,
                 freshness: nil,
-                texts: subdescriptions,
+                texts: subdescriptions
             )
         }
 
@@ -260,7 +298,7 @@ extension ProductCell {
     /// 수량 증감 뷰 사용 여부
     private var usesUpDownCountView: Bool {
         switch cellType {
-        case .defaultType, .homeType:
+        case .defaultType, .homeType, .searchType:
             return true
         case .detailType, .registType, .unclassifiedType:
             return false
@@ -282,49 +320,92 @@ private extension ProductCell {
     }
     
     /// 설명 스택에 삽입될 텍스트 라벨 제작 메소드
+    private func makeHighlightedAttributedString(
+        _ text: String,
+        keyword: String,
+        baseFont: UIFont,
+        baseColor: UIColor
+    ) -> NSAttributedString {
+        let attributed = NSMutableAttributedString(
+            string: text,
+            attributes: [
+                .font: baseFont,
+                .foregroundColor: baseColor
+            ]
+        )
+        let lowercasedText = text.lowercased()
+        let lowercasedKeyword = keyword.lowercased()
+        var searchRange = lowercasedText.startIndex..<lowercasedText.endIndex
+
+        while let range = lowercasedText.range(of: lowercasedKeyword, range: searchRange) {
+            attributed.addAttribute(
+                .foregroundColor,
+                value: UIColor.primaryRed,
+                range: NSRange(range, in: text)
+            )
+            searchRange = range.upperBound..<lowercasedText.endIndex
+        }
+
+        return attributed
+    }
+
     private func updateDescriptionStack(
         stackView: UIStackView,
         freshness: Int?,
         texts: [String]?,
-        highlightFirst: Bool = false
+        highlightFirst: Bool = false,
+        keyword: String? = nil
     ) {
         stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         var labels: [UILabel] = []
         
         /// 유통기한 텍스트 생성
         if let freshness {
-            let freshnessLabel = StyledLabel(
-                config: .body12.updatingColor(color: .primaryRed)
-            ).then {
-                if freshness > 0 {
-                    $0.text =  "\(freshness)일 남음"
-                } else if freshness == 0 {
-                    $0.text =  "오늘 만료"
-                } else {
-                    $0.text =  "유통기한 만료"
-                }
+            let freshnessText: String
+            if freshness > 0 { freshnessText = "\(freshness)일 남음" }
+            else if freshness == 0 { freshnessText = "오늘 만료" }
+            else { freshnessText = "유통기한 만료" }
+
+            let freshnessLabel = UILabel().then {
+                $0.font = LabelConfiguration.body12.font
+                $0.textColor = .primaryRed
+                $0.text = freshnessText
                 $0.numberOfLines = 1
             }
             labels.append(freshnessLabel)
         }
-        
+
         /// 설명 라벨 생성
-        texts?.enumerated().forEach { index ,text in
-            let color: UIColor = (highlightFirst && index == 0) ? .primaryRed : .gray300
-            let label = StyledLabel(config: .body12.updatingColor(color: color)).then {
-                $0.text = text
+        texts?.enumerated().forEach { index, text in
+            let baseColor: UIColor = (highlightFirst && index == 0) ? .primaryRed : .gray300
+            let label = UILabel().then {
+                $0.font = LabelConfiguration.body12.font
+                $0.textColor = baseColor
                 $0.numberOfLines = 1
+                if let keyword, !keyword.isEmpty,
+                   text.lowercased().contains(keyword.lowercased()) {
+                    $0.attributedText = makeHighlightedAttributedString(
+                        text,
+                        keyword: keyword,
+                        baseFont: LabelConfiguration.body12.font,
+                        baseColor: baseColor
+                    )
+                } else {
+                    $0.text = text
+                }
             }
             labels.append(label)
         }
-        
+
         /// 스택뷰에 삽입
         labels.enumerated().forEach { index, label in
             stackView.addArrangedSubview(label)
-            
+
             // dot 라벨 추가
             if index < labels.count - 1 {
-                let dotLabel = StyledLabel(config: .body12.updatingColor(color: .gray300)).then {
+                let dotLabel = UILabel().then {
+                    $0.font = LabelConfiguration.body12.font
+                    $0.textColor = .gray300
                     $0.text = "·"
                     $0.numberOfLines = 1
                 }
@@ -345,13 +426,6 @@ private extension ProductCell {
         backgroundConfig.backgroundColor = .white
         backgroundConfig.cornerRadius = 8
         self.backgroundConfiguration = backgroundConfig
-
-//        directionalLayoutMargins = NSDirectionalEdgeInsets(
-//            top: 8,
-//            leading: 16,
-//            bottom: 8,
-//            trailing: 16
-//        )
 
         contentView.addSubview(productMainStack)
         contentView.addSubview(productCountView)

--- a/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/ProductDetailViewController.swift
@@ -27,6 +27,12 @@ final class ProductDetailViewController: BaseViewController {
 
     let disposeBag = DisposeBag()
     private let viewWillAppearRelay = PublishRelay<Void>()
+    private let listAddButton = UIBarButtonItem(
+        image: UIImage(named: "ListAdd"),
+        style: .plain,
+        target: nil,
+        action: nil
+    )
 
     let productDetailView = ProductDetailView()
 
@@ -76,11 +82,29 @@ extension ProductDetailViewController {
             .map { _ in }
             .asObservable()
         
+        let addToCartTapped = listAddButton.rx.tap
+            .flatMapLatest { [weak self] _ in
+                AlertController.rx.alert(
+                    on: self,
+                    image: UIImage(named: "alertBlue") ?? UIImage(),
+                    title: "구매 예정 목록 추가",
+                    message: "구매 예정 목록에 추가하시겠습니까?",
+                    actions: [
+                        .cancel("취소"),
+                        .default("확인")
+                    ]
+                )
+            }
+            .filter { $0.title == "확인" }
+            .map { _ in }
+            .asObservable()
+
         let input = ProductDetailViewModel.Input(
             viewDidLoad: Observable.just(()),
             viewWillAppear: viewWillAppearRelay.asObservable(),
             modifyTapped: productDetailView.modifyButton.rx.tap.asObservable(),
-            deleteTapped: deleteTap
+            deleteTapped: deleteTap,
+            addToCartTapped: addToCartTapped
         )
 
         let output = viewModel.transform(input)
@@ -152,11 +176,13 @@ extension ProductDetailViewController {
             .font: LabelConfiguration.titleSemi18.font,
             .foregroundColor: UIColor.gray800
         ]
-        
+
         navigationController?.navigationBar.standardAppearance = appearance
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
         navigationController?.navigationBar.compactAppearance = appearance
         navigationController?.navigationBar.tintColor = .gray800
+
+        navigationItem.rightBarButtonItem = listAddButton
     }
     
     private func configureUI() {

--- a/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
+++ b/JaengYeo/JaengYeo/View/Stock/StockSearchViewController.swift
@@ -49,6 +49,7 @@ final class StockSearchViewController: BaseViewController {
     private lazy var dataSource = configureDataSource()
     weak var delegate: StockSearchViewControllerDelegate?
 
+    private var currentKeyword: String = ""
     private let recentSearchDeletedRelay = PublishRelay<UUID>()
     private let deleteAllRecentSearchRelay = PublishRelay<Void>()
     private let productQuantityIncreasedRelay = PublishRelay<Product>()
@@ -159,7 +160,9 @@ private extension StockSearchViewController {
         Observable.combineLatest(searchText, output.recentSearches, output.products)
             .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak self] text, searches, products in
-                let isEmpty = text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                self?.currentKeyword = trimmed
+                let isEmpty = trimmed.isEmpty
                 self?.applySnapshot(
                     recentSearches: isEmpty ? searches : [],
                     products: isEmpty ? [] : products
@@ -214,7 +217,7 @@ private extension StockSearchViewController {
     /// 스냅샷
     func applySnapshot(recentSearches: [RecentSearchPayload], products: [ProductCellItem]) {
         var snapshot = NSDiffableDataSourceSnapshot<Section, SearchItem>()
-        
+
         if !recentSearches.isEmpty {
             snapshot.appendSections([.recentSearch])
             snapshot.appendItems(
@@ -222,14 +225,15 @@ private extension StockSearchViewController {
                 toSection: .recentSearch
             )
         }
-        
+
         if !products.isEmpty {
+            let productItems = products.map { SearchItem.product($0) }
             snapshot.appendSections([.searchResult])
-            snapshot.appendItems(
-                products.map { .product($0) },
-                toSection: .searchResult
-            )
+            snapshot.appendItems(productItems, toSection: .searchResult)
+            /// 아이템이 동일해도 keyword 변경 시 셀 재구성 강제
+            snapshot.reconfigureItems(productItems)
         }
+
         dataSource.apply(snapshot, animatingDifferences: false)
     }
     
@@ -256,19 +260,14 @@ private extension StockSearchViewController {
                 let calendar = Calendar.current
                 let today = calendar.startOfDay(for: Date())
                 let expiryDay = calendar.startOfDay(for: expiryDate)
-                
-                freshness = calendar.dateComponents(
-                    [.day],
-                    from: today,
-                    to: expiryDay
-                ).day
+                freshness = calendar.dateComponents([.day], from: today, to: expiryDay).day
             }
 
             let descriptions = [
                 item.midCategory,
                 item.subCategory
             ].compactMap { $0 }
-            
+
             var image: UIImage?
             if let url = item.product.imageUrl {
                 image = ImageUtils.loadImage(fileName: url)
@@ -277,13 +276,14 @@ private extension StockSearchViewController {
             }
 
             cell.updateUI(
-                type: .homeType,
+                type: .searchType,
                 title: item.product.name,
                 freshness: freshness,
                 descriptions: descriptions,
                 subdescriptions: nil,
                 count: item.product.quantity,
-                image: image
+                image: image,
+                keyword: self?.currentKeyword
             )
 
             cell.bindAddButtonTap { [weak self] in

--- a/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
@@ -148,6 +148,6 @@ private extension CartViewModel {
             return
         }
 
-        cartItemsRelay.accept(items.map { $0.toDomain })
+        cartItemsRelay.accept(items.map { $0.toDomain() })
     }
 }

--- a/JaengYeo/JaengYeo/ViewModel/Stock/ProductDetailViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/ProductDetailViewModel.swift
@@ -53,12 +53,14 @@ final class ProductDetailViewModel: NSObject, ViewModelProtocol {
         let viewWillAppear: Observable<Void>
         let modifyTapped: Observable<Void>
         let deleteTapped: Observable<Void>
+        let addToCartTapped: Observable<Void>
     }
-    
+
     struct Output {
         let viewUpdate: Observable<ProductDetailDisplayModel>
         let deleteSuccess: Observable<Bool>
         let modify: Observable<(formData: RegisterFormData, originalPayload: ProductPayload)>
+        let addToCartSuccess: Observable<Void>
     }
     
     func transform(_ input: Input) -> Output {
@@ -75,14 +77,16 @@ final class ProductDetailViewModel: NSObject, ViewModelProtocol {
             )
         }
         .compactMap { $0 }
-        
+
+        let addToCartSuccessSubject = PublishSubject<Void>()
+
         Observable.merge(input.viewDidLoad, input.viewWillAppear)
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
                 self.bindProduct()
             })
             .disposed(by: disposeBag)
-        
+
         input.deleteTapped
             .subscribe(onNext: { [weak self] _ in
                 guard let self else { return }
@@ -90,7 +94,24 @@ final class ProductDetailViewModel: NSObject, ViewModelProtocol {
                 self.deleteRelay.accept(ok)
             })
             .disposed(by: disposeBag)
-        
+
+        input.addToCartTapped
+            .withLatestFrom(productRelay.compactMap { $0 })
+            .subscribe(onNext: { [weak self] product in
+                guard let self else { return }
+                let payload = CartItemPayload(
+                    id: UUID(),
+                    referenceId: product.id,
+                    name: product.name,
+                    mainCategory: product.mainCategory,
+                    quantity: 1,
+                    createdAt: Date()
+                )
+                try? self.coreDataManager.createCartItem(payload)
+                addToCartSuccessSubject.onNext(())
+            })
+            .disposed(by: disposeBag)
+
         return Output(
             viewUpdate: displayModelRelay
                 .compactMap { $0 },
@@ -98,7 +119,8 @@ final class ProductDetailViewModel: NSObject, ViewModelProtocol {
                 .skip(1)
                 .asObservable(),
             modify: input.modifyTapped
-                .withLatestFrom(modifyData)
+                .withLatestFrom(modifyData),
+            addToCartSuccess: addToCartSuccessSubject.asObservable()
         )
     }
     

--- a/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Stock/StockSearchViewModel.swift
@@ -278,9 +278,9 @@ private extension StockSearchViewModel {
                 let priority: Int?
                 if nameMatch {
                     priority = 0
-                } else if midMatch {
-                    priority = 1
                 } else if subMatch {
+                    priority = 1
+                } else if midMatch {
                     priority = 2
                 } else {
                     priority = nil


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #151 

🛠 작업 내용
- 상품 상세 화면에서 구매 예정 목록 추가 기능 구현
- 검색 화면 개편 및 키워드 하이라이트 기능 추가
- 장바구니에서 기존 제품 검색 및 상세 조회 연결

💻 구현 상세
### 상품 상세 → 구매 예정 목록 추가
- 네비게이션 바 우측에 ListAdd 버튼 추가
- 버튼 탭 시 확인 알럿 노출, 확인 시 해당 상품의 ID를 referenceId로 CartItem 생성

### 검색 화면 개편
- 검색 결과 전용 셀 타입(searchType) 추가
- 검색 우선순위 변경: 상품명 → 소분류 → 중분류
- 소비기한을 descriptions 첫 번째 항목으로 표기 (검색 타입 한정)
- 검색어와 일치하는 상품명 및 설명 텍스트 빨간색 하이라이트 처리
- 키워드 변경 시 셀 강제 재구성으로 하이라이트 실시간 반영
- 키워드 변경 시 이전 하이라이트가 잔존하는 버그 수정

### 장바구니 기존 제품 연결
- 기존제품 버튼 탭 시 재고 검색 화면으로 이동
- 검색 결과에서 제품 선택 시 상품 상세 화면으로 이동

