### PR TITLE
[장바구니] 장바구니 아이템 입고 처리 #152

### DIFF
--- a/JaengYeo/JaengYeo/Application/AppCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/AppCoordinator.swift
@@ -231,6 +231,14 @@ final class AppCoordinator {
                 mainController?.selectedIndex = Tab.register.rawValue
             })
             .disposed(by: disposeBag)
+
+        cartCoordinator.navigateToUnclassified
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak mainController, weak homeCoordinator] in
+                mainController?.selectedIndex = Tab.home.rawValue
+                homeCoordinator?.pushUnclassifiedList()
+            })
+            .disposed(by: disposeBag)
         
         window.rootViewController = mainController
     }

--- a/JaengYeo/JaengYeo/Application/CartCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/CartCoordinator.swift
@@ -12,6 +12,7 @@ import RxRelay
 final class CartCoordinator {
     let navigationController: UINavigationController
     let navigateToRegister = PublishSubject<Void>()
+    let navigateToUnclassified = PublishSubject<Void>()
     private let coreDataManager: CoreDataManagerProtocol
     private let authManager: AuthManagerProtocol
     private weak var currentNavigationController: UINavigationController?
@@ -85,5 +86,34 @@ extension CartCoordinator: CartViewControllerDelegate {
         )
         let viewController = CartAddItemViewController(viewModel: viewModel)
         currentNavigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func didTapConfirmButton(cartItems: [CartItem]) {
+        let viewModel = PurchaseConfirmViewModel(
+            cartItems: cartItems,
+            coreDataManager: coreDataManager,
+            authManager: authManager
+        )
+        let viewController = PurchaseConfirmViewController(viewModel: viewModel)
+        viewController.delegate = self
+        currentNavigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+extension CartCoordinator: PurchaseConfirmViewControllerDelegate {
+    func purchaseConfirmViewControllerDidFinish(
+        _ viewController: PurchaseConfirmViewController
+    ) {
+        currentNavigationController?.popToViewController(
+            currentNavigationController?.viewControllers.first { $0 is CartViewController } ?? viewController,
+            animated: true
+        )
+    }
+
+    func purchaseConfirmViewControllerDidFinishWithUnclassified(
+        _ viewController: PurchaseConfirmViewController
+    ) {
+        currentNavigationController?.popToRootViewController(animated: false)
+        navigateToUnclassified.onNext(())
     }
 }

--- a/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
+++ b/JaengYeo/JaengYeo/Application/HomeCoordinator.swift
@@ -84,6 +84,12 @@ final class HomeCoordinator {
 }
 
 extension HomeCoordinator {
+    /// 미분류 목록 화면 전환
+    func pushUnclassifiedList() {
+        navigationController.popToRootViewController(animated: false)
+        pushItemList(type: .unclassified)
+    }
+
     private func pushItemList(type: ItemListType) {
         let viewModel = ItemListViewModel(coreDataManager: coreDataManager, listType: type)
         let viewController = ItemListViewController(viewModel: viewModel)

--- a/JaengYeo/JaengYeo/View/Cart/CartProductCell.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartProductCell.swift
@@ -106,6 +106,12 @@ extension CartProductCell {
         updateCheckButton(isSelected: isSelected)
     }
 
+    /// 외부 바인딩 초기화 (reconfigureItems 시 중복 구독 방지)
+    func resetExternalBindings() {
+        disposeBag = DisposeBag()
+        bind()
+    }
+
     /// 체크 버튼 선택 바인딩
     func bindCheckButtonTap(onNext: @escaping () -> Void) {
         checkButtonTap
@@ -162,6 +168,7 @@ private extension CartProductCell {
     /// 스타일 설정
     func configureStyle() {
         backgroundColor = .clear
+        backgroundConfiguration = .clear()
         contentView.backgroundColor = .white
         contentView.layer.cornerRadius = 8
         contentView.layer.borderWidth = 1

--- a/JaengYeo/JaengYeo/View/Cart/CartView.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartView.swift
@@ -30,7 +30,7 @@ final class CartView: UIView {
 
     //MARK: - Components
     private let infoView = UIView().then {
-        $0.backgroundColor = .gray50
+        $0.backgroundColor = .white
     }
 
     private let totalCountLabel = StyledLabel(
@@ -66,7 +66,7 @@ final class CartView: UIView {
         frame: .zero,
         collectionViewLayout: createLayout()
     ).then {
-        $0.backgroundColor = .gray50
+        $0.backgroundColor = .white
         $0.showsVerticalScrollIndicator = false
     }
 
@@ -122,13 +122,12 @@ extension CartView {
 
     /// 정렬 메뉴 설정
     func configureSortMenu(
-        options: [String],
-        onSelect: @escaping (String) -> Void
+        onSelect: @escaping (CartSortOption) -> Void
     ) {
         sortedButton.showsMenuAsPrimaryAction = true
         sortedButton.menu = UIMenu(
-            children: options.map { option in
-                UIAction(title: option) { _ in
+            children: CartSortOption.allCases.map { option in
+                UIAction(title: option.rawValue) { _ in
                     onSelect(option)
                 }
             }
@@ -195,6 +194,7 @@ private extension CartView {
         > { [weak self] cell, _, item in
             guard let self else { return }
 
+            cell.resetExternalBindings()
             cell.updateUI(
                 title: item.name,
                 category: item.mainCategory,
@@ -271,7 +271,7 @@ private extension CartView {
 private extension CartView {
     /// UI 설정
     func configureUI() {
-        backgroundColor = .gray50
+        backgroundColor = .white
 
         addSubview(infoView)
         addSubview(collectionView)

--- a/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
+++ b/JaengYeo/JaengYeo/View/Cart/CartViewController.swift
@@ -14,6 +14,7 @@ protocol CartViewControllerDelegate: AnyObject {
     func didTapExistingProductButton()
     func didTapNewProductButton()
     func didSelectCartItem(_ item: CartItem)
+    func didTapConfirmButton(cartItems: [CartItem])
 }
 
 final class CartViewController: BaseViewController {
@@ -24,6 +25,7 @@ final class CartViewController: BaseViewController {
     //MARK: - Properties
     private let disposeBag = DisposeBag()
     private let viewWillAppearRelay = PublishRelay<Void>()
+    private let sortOptionSelectedRelay = PublishRelay<CartSortOption>()
     weak var delegate: CartViewControllerDelegate?
 
     //MARK: - Components
@@ -87,7 +89,8 @@ private extension CartViewController {
             viewWillAppear: viewWillAppearRelay.asObservable(),
             itemDeleted: itemDeleted,
             itemQuantityIncreased: cartView.itemQuantityIncreased,
-            itemQuantityDecreased: cartView.itemQuantityDecreased
+            itemQuantityDecreased: cartView.itemQuantityDecreased,
+            sortOptionSelected: sortOptionSelectedRelay.asObservable()
         )
         
         let output = viewModel.transform(input)
@@ -98,9 +101,22 @@ private extension CartViewController {
             })
             .disposed(by: disposeBag)
 
+        output.selectedSortTitle
+            .bind(onNext: { [weak self] title in
+                self?.cartView.updateSortTitle(title)
+            })
+            .disposed(by: disposeBag)
+
         cartView.itemSelected
             .bind(onNext: { [weak self] item in
                 self?.delegate?.didSelectCartItem(item)
+            })
+            .disposed(by: disposeBag)
+
+        cartView.confirmButtonTap
+            .withLatestFrom(output.cartItems)
+            .bind(onNext: { [weak self] items in
+                self?.delegate?.didTapConfirmButton(cartItems: items)
             })
             .disposed(by: disposeBag)
     }
@@ -130,6 +146,10 @@ private extension CartViewController {
     }
     
     func configureUI() {
+        cartView.configureSortMenu { [weak self] option in
+            self?.sortOptionSelectedRelay.accept(option)
+        }
+
         view.addSubview(cartView)
 
         cartView.snp.makeConstraints {

--- a/JaengYeo/JaengYeo/View/Cart/PurchaseConfirmView.swift
+++ b/JaengYeo/JaengYeo/View/Cart/PurchaseConfirmView.swift
@@ -1,0 +1,379 @@
+//
+//  PurchaseConfirmView.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 5/3/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxCocoa
+import RxRelay
+import RxSwift
+
+/// 구매 확정 화면 셀 아이템
+struct PurchaseConfirmItem: Hashable {
+    let cartItem: CartItem
+    let isSelected: Bool
+}
+
+final class PurchaseConfirmView: UIView {
+
+    //MARK: - Enum
+    enum Section {
+        case main
+    }
+
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private let selectAllTapRelay = PublishRelay<Void>()
+    private let itemCheckTapRelay = PublishRelay<CartItem>()
+    private let itemQuantityIncreasedRelay = PublishRelay<CartItem>()
+    private let itemQuantityDecreasedRelay = PublishRelay<CartItem>()
+    private lazy var dataSource = configureDataSource()
+
+    //MARK: - Components
+    /// 안내 배너
+    private let bannerView = UIView().then {
+        $0.backgroundColor = .gray50
+        $0.layer.cornerRadius = 8
+    }
+
+    private let bannerIconView = UIImageView().then {
+        $0.image = UIImage(systemName: "info.circle")
+        $0.tintColor = .gray300
+        $0.contentMode = .scaleAspectFit
+    }
+
+    private let bannerTextStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = -4
+        $0.alignment = .leading
+        $0.distribution = .fillEqually
+    }
+
+    private let bannerTitleLabel = StyledLabel(config: .bodyMedium14).then {
+        $0.text = "실제 구매한 물품을 선택하고 수량을 확인해주세요"
+        $0.numberOfLines = 1
+        $0.updateColor(.gray800)
+    }
+
+    private let bannerDescriptionLabel = StyledLabel(
+        config: LabelConfiguration.body12.updatingColor(color: .gray500)
+    ).then {
+        $0.text = "남은 수량은 구매 예정 목록에 유지됩니다."
+        $0.numberOfLines = 1
+    }
+
+    /// 전체 선택 / 정렬 행
+    private let controlRow = UIView().then {
+        $0.backgroundColor = .white
+    }
+
+    private let selectAllButton = UIButton(type: .custom).then {
+        $0.imageView?.contentMode = .scaleAspectFit
+        $0.setImage(UIImage(named: "onIcon"), for: .normal)
+    }
+
+    private let selectAllLabel = StyledLabel(
+        config: LabelConfiguration.body12.updatingColor(color: .gray500)
+    ).then {
+        $0.text = "전체 선택 (0/0)"
+    }
+
+    private let sortedButton = UIButton(configuration: .plain()).then {
+        var config = UIButton.Configuration.plain()
+        var title = AttributedString("최근 등록순")
+        title.font = .systemFont(ofSize: 12, weight: .regular)
+        title.foregroundColor = .gray800
+
+        let symbolConfig = UIImage.SymbolConfiguration(pointSize: 10, weight: .medium)
+        config.attributedTitle = title
+        config.image = UIImage(systemName: "chevron.down", withConfiguration: symbolConfig)
+        config.baseForegroundColor = .gray800
+        config.imagePlacement = .trailing
+        config.imagePadding = 1
+        config.contentInsets = .zero
+        $0.configuration = config
+    }
+
+    /// 아이템 목록
+    private lazy var collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: createLayout()
+    ).then {
+        $0.backgroundColor = .white
+        $0.showsVerticalScrollIndicator = false
+    }
+
+    /// 재고 등록 버튼
+    private let confirmButton = StyledButton(
+        title: "재고 등록하기",
+        titleConfiguration: .defaultTitle,
+        appearanceConfiguration: .defaultAppearance
+    )
+
+    //MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        bind()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+//MARK: - Public
+extension PurchaseConfirmView {
+    /// 전체 선택 탭 이벤트
+    var selectAllTap: Observable<Void> {
+        selectAllTapRelay.asObservable()
+    }
+
+    /// 개별 아이템 체크 탭 이벤트
+    var itemCheckTap: Observable<CartItem> {
+        itemCheckTapRelay.asObservable()
+    }
+
+    /// 수량 추가 이벤트
+    var itemQuantityIncreased: Observable<CartItem> {
+        itemQuantityIncreasedRelay.asObservable()
+    }
+
+    /// 수량 차감 이벤트
+    var itemQuantityDecreased: Observable<CartItem> {
+        itemQuantityDecreasedRelay.asObservable()
+    }
+
+    /// 재고 등록하기 버튼 탭 이벤트
+    var confirmButtonTap: Observable<Void> {
+        confirmButton.rx.tap.asObservable()
+    }
+
+    /// 정렬 메뉴 설정
+    func configureSortMenu(onSelect: @escaping (CartSortOption) -> Void) {
+        sortedButton.showsMenuAsPrimaryAction = true
+        sortedButton.menu = UIMenu(
+            children: CartSortOption.allCases.map { option in
+                UIAction(title: option.rawValue) { _ in onSelect(option) }
+            }
+        )
+    }
+
+    /// 정렬 타이틀 변경
+    func updateSortTitle(_ title: String) {
+        var config = sortedButton.configuration ?? .plain()
+        var attributedTitle = AttributedString(title)
+        attributedTitle.font = .systemFont(ofSize: 12, weight: .regular)
+        attributedTitle.foregroundColor = .gray800
+        config.attributedTitle = attributedTitle
+        sortedButton.configuration = config
+    }
+
+    /// 스냅샷 적용
+    func applySnapshot(items: [PurchaseConfirmItem]) {
+        let selectedCount = items.filter { $0.isSelected }.count
+        let totalCount = items.count
+        selectAllLabel.text = "전체 선택 (\(selectedCount)/\(totalCount))"
+
+        let allSelected = totalCount > 0 && selectedCount == totalCount
+        selectAllButton.setImage(
+            UIImage(named: allSelected ? "onIcon" : "offIcon"),
+            for: .normal
+        )
+
+        var snapshot = NSDiffableDataSourceSnapshot<Section, PurchaseConfirmItem>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(items, toSection: .main)
+        snapshot.reconfigureItems(items)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+}
+
+//MARK: - Binding
+private extension PurchaseConfirmView {
+    func bind() {
+        selectAllButton.rx.tap
+            .bind(to: selectAllTapRelay)
+            .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - DataSource
+private extension PurchaseConfirmView {
+    func configureDataSource() -> UICollectionViewDiffableDataSource<Section, PurchaseConfirmItem> {
+        let cellRegistration = UICollectionView.CellRegistration<
+            CartProductCell,
+            PurchaseConfirmItem
+        > { [weak self] cell, _, item in
+            guard let self else { return }
+
+            cell.resetExternalBindings()
+            cell.updateUI(
+                title: item.cartItem.name,
+                category: item.cartItem.mainCategory,
+                count: item.cartItem.quantity,
+                isSelected: item.isSelected,
+                showsCheckBox: true
+            )
+
+            cell.bindCheckButtonTap { [weak self] in
+                self?.itemCheckTapRelay.accept(item.cartItem)
+            }
+
+            cell.bindAddButtonTap { [weak self] in
+                self?.itemQuantityIncreasedRelay.accept(item.cartItem)
+            }
+
+            cell.bindDeleteButtonTap { [weak self] in
+                self?.itemQuantityDecreasedRelay.accept(item.cartItem)
+            }
+        }
+
+        return UICollectionViewDiffableDataSource<Section, PurchaseConfirmItem>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, item in
+            collectionView.dequeueConfiguredReusableCell(
+                using: cellRegistration,
+                for: indexPath,
+                item: item
+            )
+        }
+    }
+}
+
+//MARK: - Compositional Layout
+private extension PurchaseConfirmView {
+    func createLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { _, environment in
+            var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+            configuration.showsSeparators = false
+            configuration.backgroundColor = .clear
+
+            let section = NSCollectionLayoutSection.list(
+                using: configuration,
+                layoutEnvironment: environment
+            )
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top: 0,
+                leading: 16,
+                bottom: 0,
+                trailing: 16
+            )
+            section.interGroupSpacing = 8
+            return section
+        }
+    }
+}
+
+//MARK: - Configure UI
+private extension PurchaseConfirmView {
+    func configureUI() {
+        backgroundColor = .white
+
+        addSubview(bannerView)
+        addSubview(controlRow)
+        addSubview(collectionView)
+        addSubview(confirmButton)
+
+        bannerView.addSubview(bannerIconView)
+        bannerView.addSubview(bannerTextStackView)
+        bannerTextStackView.addArrangedSubview(bannerTitleLabel)
+        bannerTextStackView.addArrangedSubview(bannerDescriptionLabel)
+
+        controlRow.addSubview(selectAllButton)
+        controlRow.addSubview(selectAllLabel)
+        controlRow.addSubview(sortedButton)
+
+        bannerView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(12)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(67)
+        }
+
+        bannerIconView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(12)
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(24)
+        }
+
+        bannerTextStackView.snp.makeConstraints {
+            $0.leading.equalTo(bannerIconView.snp.trailing).offset(8)
+            $0.trailing.equalToSuperview().inset(12)
+            $0.top.equalToSuperview().offset(10)
+            $0.bottom.equalToSuperview().inset(10)
+        }
+
+        controlRow.snp.makeConstraints {
+            $0.top.equalTo(bannerView.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(40)
+        }
+
+        selectAllButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(16)
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(24)
+        }
+
+        selectAllLabel.snp.makeConstraints {
+            $0.leading.equalTo(selectAllButton.snp.trailing).offset(6)
+            $0.centerY.equalToSuperview()
+        }
+
+        sortedButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(controlRow.snp.bottom).offset(4)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(confirmButton.snp.top).offset(-16)
+        }
+
+        confirmButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(20)
+            $0.height.equalTo(44)
+        }
+    }
+}
+
+#Preview {
+    let viewController = UIViewController()
+    let confirmView = PurchaseConfirmView()
+
+    viewController.view.addSubview(confirmView)
+    confirmView.snp.makeConstraints { $0.edges.equalToSuperview() }
+
+    confirmView.applySnapshot(items: [
+        PurchaseConfirmItem(
+            cartItem: CartItem(
+                id: UUID(),
+                referenceId: nil,
+                name: "토마토",
+                mainCategory: "식재료",
+                quantity: 8,
+                createdAt: Date()
+            ),
+            isSelected: true
+        ),
+        PurchaseConfirmItem(
+            cartItem: CartItem(
+                id: UUID(),
+                referenceId: nil,
+                name: "바나나",
+                mainCategory: "식재료",
+                quantity: 3,
+                createdAt: Date()
+            ),
+            isSelected: false
+        )
+    ])
+
+    return viewController
+}

--- a/JaengYeo/JaengYeo/View/Cart/PurchaseConfirmViewController.swift
+++ b/JaengYeo/JaengYeo/View/Cart/PurchaseConfirmViewController.swift
@@ -1,0 +1,177 @@
+//
+//  PurchaseConfirmViewController.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 5/3/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+import RxCocoa
+
+protocol PurchaseConfirmViewControllerDelegate: AnyObject {
+    func purchaseConfirmViewControllerDidFinish(
+        _ viewController: PurchaseConfirmViewController
+    )
+    func purchaseConfirmViewControllerDidFinishWithUnclassified(
+        _ viewController: PurchaseConfirmViewController
+    )
+}
+
+final class PurchaseConfirmViewController: BaseViewController {
+
+    //MARK: - ViewModel
+    private let viewModel: PurchaseConfirmViewModel
+
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private let sortOptionSelectedRelay = PublishRelay<CartSortOption>()
+    weak var delegate: PurchaseConfirmViewControllerDelegate?
+
+    //MARK: - Components
+    private let confirmView = PurchaseConfirmView()
+
+    //MARK: - Init
+    init(viewModel: PurchaseConfirmViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        hidesBottomBarWhenPushed = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationBar()
+        configureUI()
+        bind()
+    }
+}
+
+//MARK: - Binding
+private extension PurchaseConfirmViewController {
+    func bind() {
+        let confirmTapped = confirmView.confirmButtonTap
+            .flatMapLatest { [weak self] _ -> Observable<Void> in
+                guard let self else { return .empty() }
+                return AlertController.rx.alert(
+                    on: self,
+                    image: UIImage(named: "alertBlue") ?? UIImage(),
+                    title: "오늘 날짜 기준으로 재고가 등록됩니다",
+                    message: "확인을 누르시면 선택한 수량만큼 재고에 반영됩니다.\n예정 수량보다 적게 등록한 경우 남은 수량은 구매 예정 목록에 유지됩니다.",
+                    actions: [.cancel("취소"), .default("확인")]
+                )
+                .filter { $0.title == "확인" }
+                .map { _ in }
+            }
+
+        let input = PurchaseConfirmViewModel.Input(
+            viewDidLoad: Observable.just(()),
+            selectAllTapped: confirmView.selectAllTap,
+            itemCheckTapped: confirmView.itemCheckTap,
+            itemQuantityIncreased: confirmView.itemQuantityIncreased,
+            itemQuantityDecreased: confirmView.itemQuantityDecreased,
+            confirmTapped: confirmTapped,
+            sortOptionSelected: sortOptionSelectedRelay.asObservable()
+        )
+
+        let output = viewModel.transform(input)
+
+        output.items
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] items in
+                self?.confirmView.applySnapshot(items: items)
+            })
+            .disposed(by: disposeBag)
+
+        output.registerSuccess
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] in
+                self?.showSuccessAlert()
+            })
+            .disposed(by: disposeBag)
+
+        output.registerFailure
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] message in
+                self?.showFailureAlert(message: message)
+            })
+            .disposed(by: disposeBag)
+
+        output.selectedSortTitle
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: { [weak self] title in
+                self?.confirmView.updateSortTitle(title)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - Alert
+private extension PurchaseConfirmViewController {
+    func showSuccessAlert() {
+        AlertController.rx.alert(
+            on: self,
+            image: UIImage(named: "alertBlue") ?? UIImage(),
+            title: "재고 등록 완료",
+            message: "선택한 상품이 재고에 등록되었습니다.\n확인 버튼을 누르시면 [미분류 상품] 화면으로 이동합니다.",
+            actions: [.default("확인")]
+        )
+        .bind(onNext: { [weak self] _ in
+            guard let self else { return }
+            self.delegate?.purchaseConfirmViewControllerDidFinishWithUnclassified(self)
+        })
+        .disposed(by: disposeBag)
+    }
+
+    func showFailureAlert(message: String) {
+        AlertController.rx.alert(
+            on: self,
+            image: UIImage(named: "alertRed") ?? UIImage(),
+            title: "등록 실패",
+            message: message,
+            actions: [.default("확인")]
+        )
+        .subscribe()
+        .disposed(by: disposeBag)
+    }
+}
+
+//MARK: - Configure UI
+private extension PurchaseConfirmViewController {
+    func configureNavigationBar() {
+        navigationItem.title = "구매 확정"
+
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .white
+        appearance.shadowColor = .clear
+        appearance.titleTextAttributes = [
+            .font: LabelConfiguration.titleSemi18.font,
+            .foregroundColor: UIColor.gray800
+        ]
+
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.compactAppearance = appearance
+        navigationController?.navigationBar.tintColor = .gray800
+    }
+
+    func configureUI() {
+        view.backgroundColor = .white
+        confirmView.configureSortMenu { [weak self] option in
+            self?.sortOptionSelectedRelay.accept(option)
+        }
+
+        view.addSubview(confirmView)
+
+        confirmView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+}

--- a/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Cart/CartViewModel.swift
@@ -9,6 +9,16 @@ import Foundation
 import RxSwift
 import RxRelay
 
+//MARK: - Sort
+enum CartSortOption: String, CaseIterable {
+    case nameAsc = "이름순"
+    case nameDesc = "이름 역순"
+    case createdAtDesc = "등록일 최신순"
+    case createdAtAsc = "등록일 오래된순"
+    case quantityDesc = "수량 많은 순"
+    case quantityAsc = "수량 적은 순"
+}
+
 final class CartViewModel: ViewModelProtocol {
 
     //MARK: - Properties
@@ -16,6 +26,7 @@ final class CartViewModel: ViewModelProtocol {
     private var cartItemObservationDisposeBag = DisposeBag()
     private let coreDataManager: CoreDataManagerProtocol
     private let cartItemsRelay = BehaviorRelay<[CartItem]>(value: [])
+    private let selectedSortOptionRelay = BehaviorRelay<CartSortOption>(value: .createdAtDesc)
     
     struct Input {
         /// 화면 로드 이벤트
@@ -28,6 +39,8 @@ final class CartViewModel: ViewModelProtocol {
         let itemQuantityIncreased: Observable<CartItem>
         /// 장바구니 아이템 수량 감소 이벤트
         let itemQuantityDecreased: Observable<CartItem>
+        /// 정렬 선택 이벤트
+        let sortOptionSelected: Observable<CartSortOption>
     }
     
     struct Output {
@@ -37,6 +50,8 @@ final class CartViewModel: ViewModelProtocol {
         let isEmpty: Observable<Bool>
         /// 장바구니 아이템 개수
         let totalCountText: Observable<Int>
+        /// 선택된 정렬 타이틀
+        let selectedSortTitle: Observable<String>
     }
     
     func transform(_ input: Input) -> Output {
@@ -73,6 +88,14 @@ final class CartViewModel: ViewModelProtocol {
                 }
             })
             .disposed(by: disposeBag)
+
+        input.sortOptionSelected
+            .subscribe(onNext: { [weak self] option in
+                guard let self else { return }
+                self.selectedSortOptionRelay.accept(option)
+                self.applySortedItems(self.cartItemsRelay.value)
+            })
+            .disposed(by: disposeBag)
         
         return Output(
             cartItems: cartItemsRelay.asObservable(),
@@ -81,6 +104,9 @@ final class CartViewModel: ViewModelProtocol {
                 .asObservable(),
             totalCountText: cartItemsRelay
                 .map { $0.count }
+                .asObservable(),
+            selectedSortTitle: selectedSortOptionRelay
+                .map { $0.rawValue }
                 .asObservable()
         )
     }
@@ -106,7 +132,9 @@ private extension CartViewModel {
             ]
         )
         .map { $0.map { $0.toDomain } }
-        .bind(to: cartItemsRelay)
+        .subscribe(onNext: { [weak self] items in
+            self?.applySortedItems(items)
+        })
         .disposed(by: cartItemObservationDisposeBag)
     }
 
@@ -123,7 +151,7 @@ private extension CartViewModel {
 
         let updatedItem = transform(items[index])
         items[index] = updatedItem
-        cartItemsRelay.accept(items)
+        applySortedItems(items)
 
         try? coreDataManager.updateCartItem(updatedItem.toPayload)
     }
@@ -136,7 +164,7 @@ private extension CartViewModel {
             let items = cartItemsRelay.value.filter {
                 $0.id != item.id
             }
-            cartItemsRelay.accept(items)
+            applySortedItems(items)
         } catch {
             return
         }
@@ -148,6 +176,37 @@ private extension CartViewModel {
             return
         }
 
-        cartItemsRelay.accept(items.map { $0.toDomain() })
+        applySortedItems(items.map { $0.toDomain() })
+    }
+
+    /// 정렬 적용
+    func applySortedItems(_ items: [CartItem]) {
+        cartItemsRelay.accept(sortItems(items))
+    }
+
+    /// 장바구니 아이템 정렬
+    func sortItems(_ items: [CartItem]) -> [CartItem] {
+        switch selectedSortOptionRelay.value {
+        case .nameAsc:
+            return items.sorted {
+                $0.name.localizedStandardCompare($1.name) == .orderedAscending
+            }
+        case .nameDesc:
+            return items.sorted {
+                $0.name.localizedStandardCompare($1.name) == .orderedDescending
+            }
+        case .createdAtDesc:
+            return items.sorted {
+                ($0.createdAt ?? .distantPast) > ($1.createdAt ?? .distantPast)
+            }
+        case .createdAtAsc:
+            return items.sorted {
+                ($0.createdAt ?? .distantPast) < ($1.createdAt ?? .distantPast)
+            }
+        case .quantityDesc:
+            return items.sorted { $0.quantity > $1.quantity }
+        case .quantityAsc:
+            return items.sorted { $0.quantity < $1.quantity }
+        }
     }
 }

--- a/JaengYeo/JaengYeo/ViewModel/Cart/PurchaseConfirmViewModel.swift
+++ b/JaengYeo/JaengYeo/ViewModel/Cart/PurchaseConfirmViewModel.swift
@@ -1,0 +1,366 @@
+//
+//  PurchaseConfirmViewModel.swift
+//  JaengYeo
+//
+//  Created by Hanjuheon on 5/3/26.
+//
+
+import Foundation
+import RxSwift
+import RxRelay
+
+final class PurchaseConfirmViewModel: ViewModelProtocol {
+
+    //MARK: - Properties
+    private let disposeBag = DisposeBag()
+    private let coreDataManager: CoreDataManagerProtocol
+    private let authManager: AuthManagerProtocol
+
+    /// 화면 진입 시 원본 장바구니 아이템 목록 (수량 차감 기준)
+    private let originalCartItems: [CartItem]
+    /// 수량이 조정된 장바구니 아이템 목록
+    private let cartItemsRelay: BehaviorRelay<[CartItem]>
+    /// 선택된 아이템 ID 집합
+    private let selectedIDsRelay: BehaviorRelay<Set<UUID>>
+    /// 선택된 정렬
+    private let selectedSortOptionRelay = BehaviorRelay<CartSortOption>(value: .createdAtDesc)
+
+    //MARK: - Input / Output
+    struct Input {
+        /// 화면 로드 이벤트
+        let viewDidLoad: Observable<Void>
+        /// 전체 선택/해제 탭 이벤트
+        let selectAllTapped: Observable<Void>
+        /// 개별 아이템 체크 탭 이벤트
+        let itemCheckTapped: Observable<CartItem>
+        /// 수량 추가 이벤트
+        let itemQuantityIncreased: Observable<CartItem>
+        /// 수량 차감 이벤트
+        let itemQuantityDecreased: Observable<CartItem>
+        /// 재고 등록하기 버튼 탭 이벤트
+        let confirmTapped: Observable<Void>
+        /// 정렬 선택 이벤트
+        let sortOptionSelected: Observable<CartSortOption>
+    }
+
+    struct Output {
+        /// 화면에 표시할 아이템 목록
+        let items: Observable<[PurchaseConfirmItem]>
+        /// 재고 등록 성공 이벤트
+        let registerSuccess: Observable<Void>
+        /// 재고 등록 실패 메시지
+        let registerFailure: Observable<String>
+        /// 선택된 정렬 타이틀
+        let selectedSortTitle: Observable<String>
+    }
+
+    //MARK: - Init
+    init(
+        cartItems: [CartItem],
+        coreDataManager: CoreDataManagerProtocol,
+        authManager: AuthManagerProtocol
+    ) {
+        self.coreDataManager = coreDataManager
+        self.authManager = authManager
+        self.originalCartItems = cartItems
+        self.cartItemsRelay = BehaviorRelay(value: cartItems)
+        self.selectedIDsRelay = BehaviorRelay(
+            value: Set(cartItems.map { $0.id })
+        )
+    }
+
+    func transform(_ input: Input) -> Output {
+        let registerSuccessSubject = PublishSubject<Void>()
+        let registerFailureSubject = PublishSubject<String>()
+
+        input.selectAllTapped
+            .withLatestFrom(
+                Observable.combineLatest(cartItemsRelay, selectedIDsRelay)
+            )
+            .subscribe(onNext: { [weak self] items, selectedIDs in
+                guard let self else { return }
+                let allSelected = selectedIDs.count == items.count
+                if allSelected {
+                    self.selectedIDsRelay.accept([])
+                } else {
+                    self.selectedIDsRelay.accept(Set(items.map { $0.id }))
+                }
+            })
+            .disposed(by: disposeBag)
+
+        input.itemCheckTapped
+            .withLatestFrom(selectedIDsRelay) { item, selectedIDs in
+                (item, selectedIDs)
+            }
+            .subscribe(onNext: { [weak self] item, selectedIDs in
+                guard let self else { return }
+                var updated = selectedIDs
+                if updated.contains(item.id) {
+                    updated.remove(item.id)
+                } else {
+                    updated.insert(item.id)
+                }
+                self.selectedIDsRelay.accept(updated)
+            })
+            .disposed(by: disposeBag)
+
+        input.itemQuantityIncreased
+            .subscribe(onNext: { [weak self] item in
+                self?.updateQuantity(id: item.id) { $0.increased() }
+            })
+            .disposed(by: disposeBag)
+
+        input.itemQuantityDecreased
+            .subscribe(onNext: { [weak self] item in
+                self?.updateQuantity(id: item.id) { $0.decreased() }
+            })
+            .disposed(by: disposeBag)
+
+        input.confirmTapped
+            .withLatestFrom(
+                Observable.combineLatest(cartItemsRelay, selectedIDsRelay)
+            )
+            .subscribe(onNext: { [weak self] items, selectedIDs in
+                guard let self else { return }
+                let selectedItems = items.filter { selectedIDs.contains($0.id) }
+                guard !selectedItems.isEmpty else {
+                    registerFailureSubject.onNext("상품을 하나 이상 선택해주세요.")
+                    return
+                }
+                self.registerItems(
+                    selectedItems,
+                    successSubject: registerSuccessSubject,
+                    failureSubject: registerFailureSubject
+                )
+            })
+            .disposed(by: disposeBag)
+
+        input.sortOptionSelected
+            .bind(to: selectedSortOptionRelay)
+            .disposed(by: disposeBag)
+
+        let items = Observable.combineLatest(
+            cartItemsRelay,
+            selectedIDsRelay,
+            selectedSortOptionRelay
+        )
+            .map { items, selectedIDs, sortOption -> [PurchaseConfirmItem] in
+                Self.sortItems(items, option: sortOption).map {
+                    PurchaseConfirmItem(
+                        cartItem: $0,
+                        isSelected: selectedIDs.contains($0.id)
+                    )
+                }
+            }
+
+        return Output(
+            items: items,
+            registerSuccess: registerSuccessSubject.asObservable(),
+            registerFailure: registerFailureSubject.asObservable(),
+            selectedSortTitle: selectedSortOptionRelay
+                .map { $0.rawValue }
+                .asObservable()
+        )
+    }
+}
+
+//MARK: - Sort
+private extension PurchaseConfirmViewModel {
+    static func sortItems(
+        _ items: [CartItem],
+        option: CartSortOption
+    ) -> [CartItem] {
+        switch option {
+        case .nameAsc:
+            return items.sorted {
+                $0.name.localizedStandardCompare($1.name) == .orderedAscending
+            }
+        case .nameDesc:
+            return items.sorted {
+                $0.name.localizedStandardCompare($1.name) == .orderedDescending
+            }
+        case .createdAtDesc:
+            return items.sorted {
+                ($0.createdAt ?? .distantPast) > ($1.createdAt ?? .distantPast)
+            }
+        case .createdAtAsc:
+            return items.sorted {
+                ($0.createdAt ?? .distantPast) < ($1.createdAt ?? .distantPast)
+            }
+        case .quantityDesc:
+            return items.sorted { $0.quantity > $1.quantity }
+        case .quantityAsc:
+            return items.sorted { $0.quantity < $1.quantity }
+        }
+    }
+}
+
+//MARK: - Quantity
+private extension PurchaseConfirmViewModel {
+    func updateQuantity(id: UUID, transform: (CartItem) -> CartItem) {
+        var items = cartItemsRelay.value
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        items[index] = transform(items[index])
+        cartItemsRelay.accept(items)
+    }
+}
+
+//MARK: - Register
+private extension PurchaseConfirmViewModel {
+    func registerItems(
+        _ items: [CartItem],
+        successSubject: PublishSubject<Void>,
+        failureSubject: PublishSubject<String>
+    ) {
+        guard let userId = authManager.currentUserId else {
+            failureSubject.onNext("로그인이 필요합니다.")
+            return
+        }
+
+        do {
+            for item in items {
+                if let referenceId = item.referenceId {
+                    let isFoodstuff = item.mainCategory == MainCategory.foodstuff.rawValue
+                    if isFoodstuff {
+                        /// 식재료: 기존 상품 정보를 복사해 새 상품으로 등록
+                        try copyProductAsNew(referenceId: referenceId, quantity: item.quantity, userId: userId)
+                    } else {
+                        /// 생활용품: 기존 상품 수량 합산
+                        try increaseExistingProduct(referenceId: referenceId, quantity: item.quantity)
+                    }
+                } else {
+                    try createNewProduct(from: item, userId: userId)
+                }
+                let originalQuantity = originalCartItems.first(where: { $0.id == item.id })?.quantity ?? item.quantity
+                let remaining = originalQuantity - item.quantity
+                if remaining > 0 {
+                    /// 등록 수량이 원본보다 적으면 차감 후 잔여 수량으로 업데이트
+                    let updatedItem = CartItem(
+                        id: item.id,
+                        referenceId: item.referenceId,
+                        name: item.name,
+                        mainCategory: item.mainCategory,
+                        quantity: remaining,
+                        createdAt: item.createdAt
+                    )
+                    try coreDataManager.updateCartItem(updatedItem.toPayload)
+                } else {
+                    try coreDataManager.deleteCartItem(id: item.id)
+                }
+            }
+            successSubject.onNext(())
+        } catch {
+            failureSubject.onNext("재고 등록 중 오류가 발생했습니다.")
+        }
+    }
+
+    /// 식재료: 기존 상품 정보를 복사해 새 UUID로 상품 생성
+    func copyProductAsNew(referenceId: UUID, quantity: Int, userId: UUID) throws {
+        let ref = try coreDataManager.fetchProduct(of: referenceId)
+        let now = Date()
+
+        /// 기존 구매일 대비 소비기한 간격을 계산해 새 구매일에 동일하게 적용
+        let newExpiryDate: Date? = {
+            guard
+                let refPurchaseDate = ref.purchaseDate,
+                let refExpiryDate = ref.expiryDate
+            else { return nil }
+            let shelfLife = refExpiryDate.timeIntervalSince(refPurchaseDate)
+            return now.addingTimeInterval(shelfLife)
+        }()
+
+        let payload = ProductPayload(
+            id: UUID(),
+            userId: userId,
+            name: ref.name,
+            quantity: Int32(quantity),
+            quantityUnit: ref.quantityUnit,
+            mainCategory: ref.mainCategory,
+            midCategoryId: ref.midCategoryId,
+            subCategoryId: ref.subCategoryId,
+            purchaseDate: now,
+            expiryDate: newExpiryDate,
+            price: 0,
+            locationMemo: nil,
+            memo: nil,
+            imageUrl: ref.imageUrl,
+            isClassified: ref.isClassified,
+            lowStockThreshold: ref.lowStockThreshold,
+            isFavorite: false,
+            createdAt: now,
+            updatedAt: now,
+            syncStatus: SyncStatus.pendingUpload.rawValue,
+            isLowStockNotificationEnabled: false,
+            caution: nil,
+            brand: ref.brand
+        )
+        try coreDataManager.createProduct(payload)
+    }
+
+    /// 생활용품: 기존 상품 수량 합산
+    func increaseExistingProduct(referenceId: UUID, quantity: Int) throws {
+        let ref = try coreDataManager.fetchProduct(of: referenceId)
+        let updatedQuantity = min(
+            Int(ref.quantity) + quantity,
+            CartItem.maxQuantity
+        )
+
+        let payload = ProductPayload(
+            id: ref.id,
+            userId: ref.userId,
+            name: ref.name,
+            quantity: Int32(updatedQuantity),
+            quantityUnit: ref.quantityUnit,
+            mainCategory: ref.mainCategory,
+            midCategoryId: ref.midCategoryId,
+            subCategoryId: ref.subCategoryId,
+            purchaseDate: ref.purchaseDate,
+            expiryDate: ref.expiryDate,
+            price: ref.price,
+            locationMemo: ref.locationMemo,
+            memo: ref.memo,
+            imageUrl: ref.imageUrl,
+            isClassified: ref.isClassified,
+            lowStockThreshold: ref.lowStockThreshold,
+            isFavorite: ref.isFavorite,
+            createdAt: ref.createdAt,
+            updatedAt: Date(),
+            syncStatus: SyncStatus.pendingUpload.rawValue,
+            isLowStockNotificationEnabled: ref.isLowStockNotificationEnabled,
+            caution: ref.caution,
+            brand: ref.brand
+        )
+        try coreDataManager.updateProduct(payload)
+    }
+
+    /// 신규 상품 생성
+    func createNewProduct(from item: CartItem, userId: UUID) throws {
+        let now = Date()
+        let payload = ProductPayload(
+            id: UUID(),
+            userId: userId,
+            name: item.name,
+            quantity: Int32(item.quantity),
+            quantityUnit: nil,
+            mainCategory: item.mainCategory,
+            midCategoryId: nil,
+            subCategoryId: nil,
+            purchaseDate: now,
+            expiryDate: nil,
+            price: 0,
+            locationMemo: nil,
+            memo: nil,
+            imageUrl: nil,
+            isClassified: false,
+            lowStockThreshold: nil,
+            isFavorite: false,
+            createdAt: now,
+            updatedAt: now,
+            syncStatus: SyncStatus.pendingUpload.rawValue,
+            isLowStockNotificationEnabled: false,
+            caution: nil,
+            brand: nil
+        )
+        try coreDataManager.createProduct(payload)
+    }
+}


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #152

## 🛠 작업 내용 (What I did)
- 구매 예정 목록에서 구매 확정 화면으로 이동하는 플로우를 추가하고, 선택한 상품만 재고에 반영되도록 구현
- 구매 확정 화면에서 전체 선택 / 개별 선택 / 수량 증감 / 정렬 기능을 사용할 수 있도록 구성
- 구매 확정 완료 후 신규 상품은 미분류 재고로 등록하고, 홈 탭을 거쳐 미분류 상품 화면으로 이동하도록 연결
- 장바구니 목록에도 정렬 기능을 추가하고, 셀 재사용 시 버튼 이벤트 중복 호출이 발생하지 않도록 개선

## 💻 구현 상세 (Implementation Details)
- PurchaseConfirmView: 안내 배너, 전체 선택 영역, 정렬 버튼, 상품 목록, 재고 등록 버튼 UI 구성
- PurchaseConfirmViewController: 구매 확정 알럿, 선택 검증 알럿, 등록 성공/실패 알럿 처리
- PurchaseConfirmViewModel: 선택된 상품만 재고에 반영하고 장바구니 잔여 수량 차감 또는 삭제 처리
- CartViewModel: 이름순 / 이름 역순 / 등록일 최신순 / 등록일 오래된순 / 수량 많은 순 / 수량 적은 순 정렬 로직 추가
- CartViewController / CartView: 정렬 메뉴 연결 및 구매 확정 버튼 탭 시 선택 목록을 Coordinator로 전달
- CartProductCell: 셀 재사용 및 reconfigure 시 버튼 이벤트 중복 바인딩 방지
- CartCoordinator: 구매 확정 화면 push 및 등록 완료 후 미분류 화면 이동 이벤트 처리
- AppCoordinator / HomeCoordinator: 구매 확정 완료 후 홈 탭 전환 및 미분류 상품 화면 진입 흐름 연결
- 생활용품 재고 반영 로직: 기존 재고 수량 합산 시 최대 수량 999를 초과하지 않도록 방어 처리